### PR TITLE
feat: Add support for APT repository management

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,31 @@
----
 version: 2
+# Specifies the configuration version for Dependabot. Version 2 is the latest version.
+
 updates:
-  - package-ecosystem: github-actions
+  # Configuration for updating GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Specifies that GitHub Actions is the package ecosystem to be updated.
     directory: "/"
+    # Sets the directory within the repository where Dependabot looks for GitHub Actions definitions.
+    # "/" indicates the root directory of the repository.
+
     schedule:
-      interval: monthly
-    reviewers:
-      - sbaerlocher
-    assignees:
-      - sbaerlocher
+      interval: "weekly"
+      # Defines the update frequency. "weekly" means Dependabot checks for updates once a week.
+      day: "friday"
+      # Specifies the day of the week when Dependabot should run, set here to Friday.
+      time: "13:00"
+      # Sets the time for the Dependabot run. "13:00" is 1:00 PM UTC, corresponding to 2:00 PM in Zurich during winter.
+
     commit-message:
-      prefix: fix
-      prefix-development: chore
-      include: scope
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+      # Configures the commit message settings for Dependabot.
+      # 'prefix' and 'prefix-development' set a prefix for commit messages.
+      # 'include: "scope"' includes the scope of the dependencies in the commit message.
+
+    assignees:
+      - "sbaerlocher"
+      # Specifies GitHub users to be automatically assigned to Dependabot pull requests.
+      # Here, 'sbaerlocher' is the user who will be assigned to the pull requests.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Get the version name from the tags
         run: |
@@ -18,7 +18,7 @@ jobs:
           echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: Publish Ansible Collection
-        uses: artis3n/ansible_galaxy_collection@v2.9.0
+        uses: arillso/action.ansible.collection@1.3.0
         with:
           api_key: "${{ secrets.GALAXY_API_KEY }}"
           galaxy_version: "${{ env.RELEASE_VERSION }}"

--- a/roles/apt_cache/README.md
+++ b/roles/apt_cache/README.md
@@ -1,3 +1,45 @@
-# Ansible Role: arillso.system.apt_cache
+# arillso.system.apt_cache
 
-## Description
+This Ansible role is designed for updating the APT package cache. It ensures that the cache is up-to-date and not expired.
+
+## Requirements
+
+- **Ansible Version**: 2.15 or higher
+- **Access**: Adequate permissions to update the APT package cache on target systems
+
+## Role Variables
+
+Variables for customizing the APT cache update are defined in `defaults/main.yml`. Users can override these in their playbook. Key variables include:
+
+### APT Cache Configuration
+
+- `apt_cache_valid_time`: The maximum age (in seconds) of the package cache before it is considered stale and needs to be updated (default: 86400).
+- `apt_cache_update_cache_retries`: The maximum number of attempts to retry updating the cache if it fails (default: 5).
+- `apt_cache_update_cache_retry_max_delay`: The maximum delay (in seconds) between retry attempts when updating the cache (default: 12).
+- `apt_cache_force_apt_get`: Whether to force the use of apt-get instead of apt when updating the cache (default: true).
+
+## Documentation
+
+For detailed information and advanced usage, please refer to our guide:
+
+[Arillso System Guide](https://guide.arillso.io/collections/arillso/system/apt_cache.html#ansible-collections-arillso-system-apt-cache-role)
+
+## Dependencies
+
+This role is standalone and does not require other Ansible roles as dependencies.
+
+## Example Playbook
+
+Example playbook for using `arillso.system.apt_cache`:
+
+```yaml
+- hosts: all
+  become: yes
+  roles:
+    - arillso.system.apt_cache
+  vars:
+    apt_cache_valid_time: 72000
+    apt_cache_update_cache_retries: 3
+    apt_cache_update_cache_retry_max_delay: 10
+    apt_cache_force_apt_get: false
+```

--- a/roles/apt_cache/defaults/main.yml
+++ b/roles/apt_cache/defaults/main.yml
@@ -1,5 +1,12 @@
 ---
+# The maximum age (in seconds) of the package cache before it is considered stale and needs to be updated.
 apt_cache_valid_time: 86400
+
+# The maximum number of attempts to retry updating the cache if it fails.
 apt_cache_update_cache_retries: 5
+
+# The maximum delay (in seconds) between retry attempts when updating the cache.
 apt_cache_update_cache_retry_max_delay: 12
+
+# Whether to force the use of apt-get instead of apt when updating the cache.
 apt_cache_force_apt_get: true

--- a/roles/apt_keys/README.md
+++ b/roles/apt_keys/README.md
@@ -1,3 +1,49 @@
-# Ansible Role: arillso.system.apt_keys
+# arillso.system.apt_keys
 
-## Description
+This Ansible role is designed for managing APT keys on a system. It utilizes the `ansible.builtin.apt_key` module
+to add or remove APT keys as specified in the role's configuration.
+
+## Requirements
+
+- **Ansible Version**: 2.15 or higher
+- **Access**: Adequate permissions to manage APT keys on target systems
+
+## Role Variables
+
+Variables for managing APT keys are defined in `defaults/main.yml`. Users can override these in their playbook. Key variables include:
+
+### APT Keys Configuration
+
+- `apt_keys_list`: A list of dictionaries specifying APT keys to manage. Each dictionary should contain:
+  - `id`: The ID of the APT key.
+  - `url`: The URL from where the APT key can be downloaded.
+  - `state`: Optional. The state of the APT key (can be 'present' or 'absent'). If not specified, `apt_keys_state` will be used (default: 'present').
+
+- `apt_keys_state`: The default state of APT keys if not specified in each key dictionary. Can be 'present' or 'absent' (default: 'present').
+
+## Documentation
+
+For detailed information and advanced usage, please refer to our guide:
+
+[Arillso System Guide](https://guide.arillso.io/collections/arillso/system/apt_keys.html#ansible-collections-arillso-system-apt-keys-role)
+
+## Dependencies
+
+This role is standalone and does not require other Ansible roles as dependencies.
+
+## Example Playbook
+
+Example playbook for using `arillso.system.apt_keys`:
+
+```yaml
+- hosts: all
+  become: yes
+  roles:
+    - arillso.system.apt_keys
+  vars:
+    apt_keys_list:
+      - id: 'E0C56BD4'
+        url: 'http://keyserver.ubuntu.com:80'
+        state: 'present'
+    apt_keys_state: 'present'
+```

--- a/roles/apt_keys/defaults/main.yml
+++ b/roles/apt_keys/defaults/main.yml
@@ -1,3 +1,10 @@
 ---
-apt_keys_list: []
-apt_keys_state: present
+# A list of apt keys to be managed. Each entry in the list should be a dictionary with 'id', 'url', and optionally 'state'.
+apt_keys_list:
+  # Beispiel:
+  # - id: 'E0C56BD4'  # The ID of the key.
+  #   url: 'http://keyserver.ubuntu.com:80'  # The URL from where the key can be downloaded.
+  #   state: 'present'  # Optional: state of the key ('present' or 'absent'). If not specified, 'apt_keys_state' will be used.
+
+# The default state for apt keys if not specified in 'apt_keys_list'. Can be 'present' or 'absent'.
+apt_keys_state: "present"

--- a/roles/apt_keys/meta/argument_specs.yml
+++ b/roles/apt_keys/meta/argument_specs.yml
@@ -1,0 +1,32 @@
+---
+argument_specs:
+  manage_apt_keys: &manage_apt_keys
+    short_description: Manage APT keys
+    description:
+      - This specification manages APT keys on a system using ansible.builtin.apt_key module.
+    options:
+      apt_keys_list:
+        type: list
+        elements: dict
+        description:
+          - A list of dictionaries specifying APT keys to manage.
+          - Each dictionary should have 'id', 'url', and optionally 'state'.
+        default: []
+        options:
+          id:
+            type: str
+            description: The ID of the APT key.
+          url:
+            type: str
+            description: The URL from where the APT key can be downloaded.
+          state:
+            type: str
+            description: The state of the APT key. Can be 'present' or 'absent'.
+            default: "{{ apt_keys_state }}"
+
+      apt_keys_state:
+        type: str
+        description: The default state of APT keys if not specified in each key dictionary. Can be 'present' or 'absent'.
+        default: present
+
+  main: *manage_apt_keys

--- a/roles/apt_packages/README.md
+++ b/roles/apt_packages/README.md
@@ -1,5 +1,58 @@
-# Ansible Role: arillso.system.apt_packages
+# arillso.system.apt_packages
 
-## Description
+This Ansible role is designed for managing APT packages on a system. It enables the installation, update, and removal
+of APT packages using the `ansible.builtin.apt` module.
 
-The role installs different packages on the apt system.
+## Requirements
+
+- **Ansible Version**: 2.15 or higher
+- **Access**: Adequate permissions to manage APT packages on target systems
+
+## Role Variables
+
+Variables for managing APT packages are defined in `defaults/main.yml`. Users can override these in their playbook. Key variables include:
+
+### APT Packages Configuration
+
+- `apt_packages_list`: A list of APT packages to manage. Each entry can be a package name or a dictionary with additional options such as
+ version, install recommends, allow downgrade, purge, force apt-get, lock timeout, and state.
+
+- `apt_packages_install_recommends`: Default value for installing recommended packages along with the main package (default: true).
+
+- `apt_packages_allow_downgrade`: Default value for allowing package downgrades (default: false).
+
+- `apt_packages_purge`: Default value for purging packages (default: false).
+
+- `apt_packages_force_apt_get`: Default value for forcing the use of apt-get instead of apt (default: false).
+
+- `apt_packages_lock_timeout`: Default value for the lock timeout when installing packages (default: 30 seconds).
+
+- `apt_packages_state`: Default state of APT packages if not specified in each package dictionary (default: 'present').
+
+## Documentation
+
+For detailed information and advanced usage, please refer to our guide:
+
+[Arillso System Guide](https://guide.arillso.io/collections/arillso/system/apt_packages.html#ansible-collections-arillso-system-apt-packages-role)
+
+## Dependencies
+
+This role is standalone and does not require other Ansible roles as dependencies.
+
+## Example Playbook
+
+Example playbook for using `arillso.system.apt_packages`:
+
+```yaml
+- hosts: all
+  become: yes
+  roles:
+    - arillso.system.apt_packages
+  vars:
+    apt_packages_list:
+      - name: 'vim'
+        state: 'latest'
+      - name: 'curl'
+        install_recommends: false
+    apt_packages_state: 'present'
+```

--- a/roles/apt_packages/defaults/main.yml
+++ b/roles/apt_packages/defaults/main.yml
@@ -1,8 +1,30 @@
 ---
-apt_packages_list: []
-apt_packages_state: present
-apt_packages_install_recommends: false
+# A list of APT packages to be managed. Each entry in the list can be either a package name or a dictionary with additional options.
+apt_packages_list:
+  # Beispiel:
+  # - name: 'vim'
+  #   version: '8.0'
+  #   install_recommends: false
+  #   allow_downgrade: false
+  #   purge: false
+  #   force_apt_get: false
+  #   lock_timeout: 30
+  #   state: 'present'
+
+# Default value for installing recommended packages along with the main package. Can be true or false.
+apt_packages_install_recommends: true
+
+# Default value for allowing package downgrades. Can be true or false.
 apt_packages_allow_downgrade: false
-apt_packages_purge: true
-apt_packages_force_apt_get: true
-apt_packages_lock_timeout: 60
+
+# Default value for purging packages. Can be true or false.
+apt_packages_purge: false
+
+# Default value for forcing the use of apt-get instead of apt. Can be true or false.
+apt_packages_force_apt_get: false
+
+# Default value for the lock timeout when installing packages. Specified in seconds.
+apt_packages_lock_timeout: 30
+
+# Default state of APT packages if not specified in each package dictionary. Can be 'present', 'absent', 'latest', etc.
+apt_packages_state: "present"

--- a/roles/apt_packages/meta/argument_specs.yml
+++ b/roles/apt_packages/meta/argument_specs.yml
@@ -1,0 +1,68 @@
+---
+argument_specs:
+  main:
+    short_description: Manage APT packages
+    description:
+      - This specification manages the installation, update, and removal of APT packages on a system.
+    options:
+      apt_packages_list:
+        type: list
+        elements: dict
+        description:
+          - A list of APT packages to manage. Each entry can be a package name or a dictionary with additional options.
+        default: []
+        options:
+          name:
+            type: str
+            description: The name of the APT package.
+          version:
+            type: str
+            description: The version of the package to be installed or managed.
+          install_recommends:
+            type: bool
+            description: Whether to install recommended packages along with the main package.
+          allow_downgrade:
+            type: bool
+            description: Whether to allow downgrading of packages.
+          purge:
+            type: bool
+            description: Whether to purge packages.
+          force_apt_get:
+            type: bool
+            description: Whether to force the use of apt-get instead of apt.
+          lock_timeout:
+            type: int
+            description: Lock timeout in seconds when installing packages.
+          state:
+            type: str
+            description: The desired state of the package ('present', 'absent', 'latest', etc.).
+
+      apt_packages_install_recommends:
+        type: bool
+        description: Default value for installing recommended packages. Used if not specified in the package list.
+        default: true
+
+      apt_packages_allow_downgrade:
+        type: bool
+        description: Default value for allowing package downgrades. Used if not specified in the package list.
+        default: false
+
+      apt_packages_purge:
+        type: bool
+        description: Default value for purging packages. Used if not specified in the package list.
+        default: false
+
+      apt_packages_force_apt_get:
+        type: bool
+        description: Default value for forcing the use of apt-get. Used if not specified in the package list.
+        default: false
+
+      apt_packages_lock_timeout:
+        type: int
+        description: Default value for the lock timeout. Used if not specified in the package list.
+        default: 30
+
+      apt_packages_state:
+        type: str
+        description: Default state of APT packages. Used if not specified in the package list.
+        default: "present"

--- a/roles/apt_packages/tasks/main.yml
+++ b/roles/apt_packages/tasks/main.yml
@@ -10,7 +10,7 @@
     apt_package_force_apt_get: "{{ apt_package.force_apt_get | default(apt_packages_force_apt_get) }}"
     apt_package_lock_timeout: "{{ apt_package.lock_timeout | default(apt_packages_lock_timeout) }}"
     apt_package_state: "{{ apt_package.state | default(apt_packages_state) }}"
-  loop: "{{ apt_packages }}"
+  loop: "{{ apt_packages_list }}"
   loop_control:
     label: "{{ apt_package_name }}"
     loop_var: apt_package

--- a/roles/apt_repositories/README.md
+++ b/roles/apt_repositories/README.md
@@ -15,7 +15,7 @@ Variables for managing APT repositories are defined in `defaults/main.yml`. User
 ### APT Repositories Configuration
 
 - `apt_repositories_list`: A list of APT repositories to manage. Each entry should be a dictionary with repository details such as
-codename, filename, repo, state, and others.
+codename, filename, repository, state, and others.
 
 - `apt_repositories_filename`: Default filename for APT repositories if not specified in each repository dictionary (default: 'default.list').
 

--- a/roles/apt_repositories/README.md
+++ b/roles/apt_repositories/README.md
@@ -1,3 +1,53 @@
-# Ansible Role: arillso.system.apt_packages
+# arillso.system.apt_repositories
 
-## Description
+This Ansible role is designed for managing APT repositories on a system. It enables the addition, modification, and removal
+of APT repositories using the `ansible.builtin.apt_repository` module.
+
+## Requirements
+
+- **Ansible Version**: 2.15 or higher
+- **Access**: Adequate permissions to manage APT repositories on target systems
+
+## Role Variables
+
+Variables for managing APT repositories are defined in `defaults/main.yml`. Users can override these in their playbook. Key variables include:
+
+### APT Repositories Configuration
+
+- `apt_repositories_list`: A list of APT repositories to manage. Each entry should be a dictionary with repository details such as
+codename, filename, repo, state, and others.
+
+- `apt_repositories_filename`: Default filename for APT repositories if not specified in each repository dictionary (default: 'default.list').
+
+- `apt_repositories_update_cache_retries`: Default value for the number of retries to update the cache after adding a repository (default: 5).
+
+- `apt_repositories_update_cache_retry_max_delay`: Default maximum delay in seconds between retries to update the cache (default: 12).
+
+- `apt_repositories_update_cache`: Default value to decide whether to update the cache after adding a repository (default: true).
+
+## Documentation
+
+For detailed information and advanced usage, please refer to our guide:
+
+[Arillso System Guide](https://guide.arillso.io/collections/arillso/system/apt_repositories.html#ansible-collections-arillso-system-apt-repositories-role)
+
+## Dependencies
+
+This role is standalone and does not require other Ansible roles as dependencies.
+
+## Example Playbook
+
+Example playbook for using `arillso.system.apt_repositories`:
+
+```yaml
+- hosts: all
+  become: yes
+  roles:
+    - arillso.system.apt_repositories
+  vars:
+    apt_repositories_list:
+      - repo: 'deb http://myrepo.example.com/debian buster main'
+        state: 'present'
+    apt_repositories_filename: 'myrepo.list'
+    apt_repositories_update_cache: true
+```

--- a/roles/apt_repositories/defaults/main.yml
+++ b/roles/apt_repositories/defaults/main.yml
@@ -1,8 +1,26 @@
 ---
-apt_repositories_list: []
-apt_repositories_force_apt_get: true
-apt_repositories_empty_sources_list: false
-apt_repositories_filename: /etc/apt/sources
-apt_repositories_update_cache_retries: "{{ omit }}"
-apt_repositories_update_cache_retry_max_delay: "{{ omit }}"
-apt_repositories_update_cache: "{{ omit }}"
+# A list of APT repositories to be managed. Each entry should be a dictionary with repository details.
+apt_repositories_list:
+  # Beispiel:
+  # - codename: 'buster'
+  #   filename: 'myrepo.list'
+  #   install_python_apt: true
+  #   mode: '0644'
+  #   repo: 'deb http://myrepo.example.com/debian buster main'
+  #   state: 'present'
+  #   update_cache_retries: 3
+  #   update_cache_retry_max_delay: 12
+  #   update_cache: true
+  #   validate_certs: true
+
+# Default filename for APT repositories if not specified in each repository dictionary.
+apt_repositories_filename: "default.list"
+
+# Default value for the number of retries to update the cache after adding a repository.
+apt_repositories_update_cache_retries: 5
+
+# Default maximum delay in seconds between retries to update the cache.
+apt_repositories_update_cache_retry_max_delay: 12
+
+# Default value to decide whether to update the cache after adding a repository.
+apt_repositories_update_cache: true

--- a/roles/apt_repositories/meta/argument_specs.yml
+++ b/roles/apt_repositories/meta/argument_specs.yml
@@ -1,0 +1,71 @@
+---
+argument_specs:
+  repositories: &repositories
+    short_description: Manage APT repositories
+    description:
+      - This specification manages the addition, modification, and removal of APT repositories on a system.
+    options:
+      apt_repositories_list:
+        type: list
+        elements: dict
+        description:
+          - A list of dictionaries specifying APT repositories to manage.
+        default: []
+        options:
+          codename:
+            type: str
+            description: Codename of the distribution version for the repository.
+          filename:
+            type: str
+            description: Filename under which the repository is stored.
+            default: "{{ apt_repositories_filename }}"
+          install_python_apt:
+            type: bool
+            description: Whether to install the python-apt package if necessary for the repository.
+          mode:
+            type: str
+            description: File permissions for the repository file.
+          repo:
+            type: str
+            description: Repository entry line (e.g., 'deb http://myrepo.example.com/debian buster main').
+          state:
+            type: str
+            description: State of the repository ('present' or 'absent').
+            default: "present"
+          update_cache_retries:
+            type: int
+            description: Number of retries to update the cache after adding the repository.
+            default: "{{ apt_repositories_update_cache_retries }}"
+          update_cache_retry_max_delay:
+            type: int
+            description: Maximum delay in seconds between retries to update the cache.
+            default: "{{ apt_repositories_update_cache_retry_max_delay }}"
+          update_cache:
+            type: bool
+            description: Whether to update the cache after adding the repository.
+            default: "{{ apt_repositories_update_cache }}"
+          validate_certs:
+            type: bool
+            description: Whether to validate SSL certificates for HTTPS repositories.
+
+      apt_repositories_filename:
+        type: str
+        description: Default filename for APT repositories if not specified in each repository dictionary.
+        default: "default.list"
+
+      apt_repositories_update_cache_retries:
+        type: int
+        description: Default value for the number of retries to update the cache after adding a repository.
+        default: 5
+
+      apt_repositories_update_cache_retry_max_delay:
+        type: int
+        description: Default maximum delay in seconds between retries to update the cache.
+        default: 12
+
+      apt_repositories_update_cache:
+        type: bool
+        description: Default value to decide whether to update the cache after adding a repository.
+        default: true
+
+  main: *repositories

--- a/roles/apt_repositories/tasks/repositories.yml
+++ b/roles/apt_repositories/tasks/repositories.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Ensure apt repositories
   ansible.builtin.include_tasks: repository.yml
   vars:
@@ -13,7 +12,7 @@
     apt_repository_update_cache_retry_max_delay: "{{ apt_repository.update_cache_retry_max_delay | default(apt_repositories_update_cache_retry_max_delay) }}"
     apt_repository_update_cache: "{{ apt_repository.update_cache | default(apt_repositories_update_cache) }}"
     apt_repository_validate_certs: "{{ apt_repository.validate_certs | default(omit) }}"
-  loop: "{{ apt_repositories }}"
+  loop: "{{ apt_repositories_list }}"
   loop_control:
     label: "{{ apt_repository_repo }}"
     loop_var: apt_repository

--- a/roles/systemd_unit/tasks/systemd_unit.yml
+++ b/roles/systemd_unit/tasks/systemd_unit.yml
@@ -7,7 +7,7 @@
     owner: root
     group: root
     mode: "0644"
-  notify: ensure systemd configuration is reloaded
+  notify: Ensure systemd configuration is reloaded
   when:
     - systemd_unit_name
     - not systemd_unit_override_name
@@ -21,7 +21,7 @@
     group: root
     mode: "0644"
     state: "{{ systemd_unit_override | ternary('directory', 'absent') }}"
-  notify: ensure systemd configuration is reloaded
+  notify: Ensure systemd configuration is reloaded
   when:
     - systemd_unit_name
     - systemd_unit_override_name
@@ -34,7 +34,7 @@
     owner: root
     group: root
     mode: "0644"
-  notify: ensure systemd configuration is reloaded
+  notify: Ensure systemd configuration is reloaded
   when:
     - systemd_unit_name
     - systemd_unit_override_name


### PR DESCRIPTION
## Added
- **Roles for APT Repository Management**: 
  - `apt_cache`: Added with README and main configuration file.
  - `apt_keys`: Included with README, main configuration, and argument specifications.
  - `apt_packages`: Added with README, main configuration, argument specifications, and main task file.
  - `apt_repositories`: Introduced with README, main configuration, argument specifications, and repository management tasks.
  - `systemd_unit`: Updated tasks for systemd unit management.

## Changed
- **.github/dependabot.yml**: Updated the configuration for Dependabot, including changes to the update frequency and commit message settings.
- **.github/workflows/publish.yml**: Updated the GitHub Actions checkout version.
