### PR TITLE
fix: apt_packages_list

### DIFF
--- a/roles/packages/tasks/install_package_debian.yml
+++ b/roles/packages/tasks/install_package_debian.yml
@@ -3,4 +3,4 @@
   ansible.builtin.include_role:
     name: arillso.system.apt_packages
   vars:
-    apt_packages_list_list: "{{ packages_list }}"
+    apt_packages_list: "{{ packages_list }}"


### PR DESCRIPTION


### Fixed
- **Apt_Packages Role:**
  - Corrected variable naming in `roles/packages/tasks/install_package_debian.yml` to ensure consistency and clarity. The variable `apt_packages_list_list` was renamed to `apt_packages_list` for better alignment with its purpose.
