### PR TITLE
fix: rename iptables_configuration #34

### DIFF
--- a/roles/iptables/handlers/main.yml
+++ b/roles/iptables/handlers/main.yml
@@ -2,37 +2,37 @@
 - name: Restart iptables
   become: true
   ansible.builtin.service:
-    name: "{{ iptables_service }}"
+    name: "{{ iptables_ipv4_service }}"
     state: restarted
 
 - name: Start iptables
   become: true
   ansible.builtin.service:
-    name: "{{ iptables_service }}"
+    name: "{{ iptables_ipv4_service }}"
     state: started
 
 - name: Enable iptables
   become: true
   ansible.builtin.service:
-    name: "{{ iptables_service }}"
+    name: "{{ iptables_ipv4_service }}"
     enabled: true
 
 - name: Restart iptables 6
   become: true
   ansible.builtin.service:
-    name: "{{ iptables_6_service }}"
+    name: "{{ iptables_ipv6_service }}"
     state: restarted
 
 - name: Start iptables 6
   become: true
   ansible.builtin.service:
-    name: "{{ iptables_6_service }}"
+    name: "{{ iptables_ipv6_service }}"
     state: started
   when: "'scope' in ansible_default_ipv6 and ansible_default_ipv6.scope == 'global'"
 
 - name: Enable iptables 6
   become: true
   ansible.builtin.service:
-    name: "{{ iptables_6_service }}"
+    name: "{{ iptables_ipv6_service }}"
     enabled: true
   when: "'scope' in ansible_default_ipv6 and ansible_default_ipv6.scope == 'global'"

--- a/roles/iptables/tasks/main.yml
+++ b/roles/iptables/tasks/main.yml
@@ -81,7 +81,7 @@
   become: true
   community.general.iptables_state:
     ip_version: "{{ item }}"
-    path: "{{ lookup('vars', 'iptables_configuration_' + item) }}"
+    path: "{{ lookup('vars', 'iptables_' + item + '_configuration') }}"
     state: saved
   loop:
     - ipv4

--- a/roles/iptables/vars/CentOS.yml
+++ b/roles/iptables/vars/CentOS.yml
@@ -4,7 +4,7 @@ iptables_packages:
   - iptables-services
   - conntrack
 
-iptables_service: iptables
-iptables_6_service: ip6tables
-iptables_configuration: /etc/sysconfig/iptables
-iptables_6_configuration: /etc/sysconfig/ip6tables
+iptables_ipv4_service: iptables
+iptables_ipv6_service: ip6tables
+iptables_ipv4_configuration: /etc/sysconfig/iptables
+iptables_ipv6_configuration: /etc/sysconfig/ip6tables

--- a/roles/iptables/vars/Debian.yml
+++ b/roles/iptables/vars/Debian.yml
@@ -3,7 +3,7 @@ iptables_packages:
   - iptables
   - iptables-persistent
 
-iptables_service: iptables
-iptables_6_service: ip6tables
-iptables_configuration: /etc/iptables/rules.v4
-iptables_6_configuration: /etc/iptables/rules.v6
+iptables_ipv4_service: iptables
+iptables_ipv6_service: ip6tables
+iptables_ipv4_configuration: /etc/iptables/rules.v4
+iptables_ipv6_configuration: /etc/iptables/rules.v6

--- a/roles/iptables/vars/Ubuntu-16.04.yml
+++ b/roles/iptables/vars/Ubuntu-16.04.yml
@@ -3,7 +3,7 @@ iptables_packages:
   - iptables
   - iptables-persistent
 
-iptables_service: netfilter-persistent
-iptables_6_service: netfilter-persistent
-iptables_configuration: /etc/iptables/rules.v4
-iptables_6_configuration: /etc/iptables/rules.v6
+iptables_ipv4_service: netfilter-persistent
+iptables_ipv6_service: netfilter-persistent
+iptables_ipv4_configuration: /etc/iptables/rules.v4
+iptables_ipv6_configuration: /etc/iptables/rules.v6

--- a/roles/iptables/vars/Ubuntu.yml
+++ b/roles/iptables/vars/Ubuntu.yml
@@ -3,7 +3,7 @@ iptables_packages:
   - iptables
   - iptables-persistent
 
-iptables_service: iptables
-iptables_6_service: ip6tables
-iptables_configuration: /etc/iptables/rules.v4
-iptables_6_configuration: /etc/iptables/rules.v6
+iptables_ipv4_service: iptables
+iptables_ipv6_service: ip6tables
+iptables_ipv4_configuration: /etc/iptables/rules.v4
+iptables_ipv6_configuration: /etc/iptables/rules.v6


### PR DESCRIPTION
### Changes
- **Variable Renaming**:
  - `iptables_service` and `iptables_6_service` to `iptables_ipv4_service` and `iptables_ipv6_service`.
  - `iptables_configuration` and `iptables_6_configuration` to `iptables_ipv4_configuration` and `iptables_ipv6_configuration`.
- **Affected Files**:
  - Modifications in main.yml, CentOS.yml, Debian.yml, Ubuntu-16.04.yml, Ubuntu.yml within iptables role.
