### PR TITLE
feat: add motd and journald role

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -29,3 +29,4 @@ jobs:
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FILTER_REGEX_EXCLUDE: .*\.j2$

--- a/roles/motd/defaults/main.yml
+++ b/roles/motd/defaults/main.yml
@@ -1,0 +1,50 @@
+---
+# Header text for the MOTD script, undefined by default
+motd_header: |2-
+       _              _ _     _
+      / \   _ __  ___(_) |__ | | ___
+     / _ \ | '_ \/ __| | '_ \| |/ _ \
+    / ___ \| | | \__ \ | |_) | |  __/
+   /_/   \_\_| |_|___/_|_.__/|_|\___|
+
+# Fully Qualified Domain Name of the host
+motd_fqdn: "{{ ansible_fqdn }}" # Uses Ansible's built-in FQDN fact
+
+# Operating System Distribution Name
+motd_distribution: "{{ ansible_distribution }}" # Uses Ansible's built-in distribution fact
+
+# Operating System Distribution Version
+motd_distribution_version: "{{ ansible_distribution_version }}" # Uses Ansible's built-in distribution version fact
+
+# Release name of the distribution
+motd_distribution_release: "{{ ansible_distribution_release }}" # Uses Ansible's built-in distribution release fact
+
+# Role in virtualization (guest/host/none)
+motd_virtualization_role: "{{ ansible_virtualization_role }}" # Uses Ansible's built-in virtualization role fact
+
+# Type of virtualization (KVM, VirtualBox, etc.)
+motd_virtualization_type: "{{ ansible_virtualization_type }}" # Uses Ansible's built-in virtualization type fact
+
+# Date and time information
+motd_date_time: "{{ ansible_date_time }}" # Uses Ansible's built-in date time fact
+
+# Region variable, undefined by default
+motd_region: undefined # Custom variable, default set to 'undefined'
+
+# Zone variable, undefined by default
+motd_zone: undefined # Custom variable, default set to 'undefined'
+
+# Customer variable, undefined by default
+motd_customer: undefined # Custom variable, default set to 'undefined'
+
+# Projects variable, undefined by default
+motd_projects: undefined # Custom variable, default set to 'undefined'
+
+# Single project variable, undefined by default
+motd_project: undefined # Custom variable, default set to 'undefined'
+
+# List of filesystem types to exclude in disk space check, empty by default
+motd_exclude_disk_space:
+  - tmpfs
+  - devtmpfs
+  - overlay

--- a/roles/motd/meta/argument_specs.yml
+++ b/roles/motd/meta/argument_specs.yml
@@ -1,0 +1,86 @@
+---
+# Argument specifications for iptables rules
+argument_specs:
+  main:
+    description:
+      - Manage the Message of the Day (MOTD) configuration including creation, modification, and deletion of MOTD content.
+    short_description: Manage MOTD configuration
+    options:
+      motd_header:
+        description: The header text for the Message of the Day (MOTD) script
+        type: str
+        default: |
+          -
+            _              _ _     _
+            / \   _ __  ___(_) |__ | | ___
+            / _ \ | '_ \/ __| | '_ \| |/ _ \
+          / ___ \| | | \__ \ | |_) | |  __/
+          /_/   \_\_| |_|___/_|_.__/|_|\___|
+
+      motd_fqdn:
+        description: Fully Qualified Domain Name of the host
+        type: str
+        default: "{{ ansible_fqdn }}"
+
+      motd_distribution:
+        description: Operating System Distribution Name
+        type: str
+        default: "{{ ansible_distribution }}"
+
+      motd_distribution_version:
+        description: Operating System Distribution Version
+        type: str
+        default: "{{ ansible_distribution_version }}"
+
+      motd_distribution_release:
+        description: Release name of the distribution
+        type: str
+        default: "{{ ansible_distribution_release }}"
+
+      motd_virtualization_role:
+        description: Role in virtualization (guest/host/none)
+        type: str
+        default: "{{ ansible_virtualization_role }}"
+
+      motd_virtualization_type:
+        description: Type of virtualization (KVM, VirtualBox, etc.)
+        type: str
+        default: "{{ ansible_virtualization_type }}"
+
+      motd_date_time:
+        description: Date and time information
+        type: dict
+        default: "{{ ansible_date_time }}"
+
+      motd_region:
+        description: Region variable
+        type: str
+        default: undefined
+
+      motd_zone:
+        description: Zone variable
+        type: str
+        default: undefined
+
+      motd_customer:
+        description: Customer variable
+        type: str
+        default: undefined
+
+      motd_projects:
+        description: Projects variable
+        type: list
+        default: undefined
+
+      motd_project:
+        description: Single project variable
+        type: str
+        default: undefined
+
+      motd_exclude_disk_space:
+        description: List of filesystem types to exclude in disk space check
+        type: list
+        default:
+          - tmpfs
+          - devtmpfs
+          - overlay

--- a/roles/motd/meta/main.yml
+++ b/roles/motd/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  description: "Installs and configures iptables"
+  author: "arillso (@arillso)"
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
+    - name: Ubuntu
+      versions:
+        - focal
+
+  galaxy_tags:
+    - networking
+
+dependencies: []

--- a/roles/motd/tasks/main.yml
+++ b/roles/motd/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+- name: "Configure 'motd'"
+  become: true
+  ansible.builtin.template:
+    src: "etc/update-motd.d/{{ item }}.j2"
+    dest: "/etc/update-motd.d/{{ item }}"
+    owner: root
+    group: root
+    mode: "755"
+  loop:
+    - 00-header
+    - 02-facts
+    - 03-sysinfo
+    - 90-updates-available
+
+- name: "Configure 'motd'"
+  become: true
+  ansible.builtin.template:
+    src: "etc/motd.j2"
+    dest: "/etc/motd"
+    owner: root
+    group: root
+    mode: "755"
+
+- name: Find files in the specified directory
+  become: true
+  ansible.builtin.find:
+    paths: "/etc/update-motd.d/"
+    file_type: file
+  register: register_files_to_check
+
+- name: Read contents of each file
+  become: true
+  ansible.builtin.slurp:
+    src: "{{ item.path }}"
+  loop: "{{ register_files_to_check.files }}"
+  register: register_file_contents
+  ignore_errors: true
+
+- name: Delete files without the Ansible header
+  become: true
+  ansible.builtin.file:
+    path: "{{ item.item.path }}"
+    state: absent
+  loop: "{{ register_file_contents.results }}"
+  when: "'# Ansible managed' not in (item['content'] | b64decode).split('\n')[1]"

--- a/roles/motd/templates/etc/update-motd.d/00-header.j2
+++ b/roles/motd/templates/etc/update-motd.d/00-header.j2
@@ -1,0 +1,5 @@
+#!/bin/sh
+# {{ ansible_managed }}
+{% if motd_header is defined %}
+echo '{{ motd_header }}'
+{% endif %}

--- a/roles/motd/templates/etc/update-motd.d/02-facts.j2
+++ b/roles/motd/templates/etc/update-motd.d/02-facts.j2
@@ -1,0 +1,25 @@
+#!/bin/sh
+# {{ ansible_managed }}
+echo "FQDN:                 {{ motd_fqdn }}"
+echo "Distro:               {{ motd_distribution }} {{ motd_distribution_version }} {{ motd_distribution_release }}"
+echo "Virtual:              {{ 'YES' if motd_virtualization_role == 'guest' else 'NO' }}"
+echo "Virtualization Type:  {{ motd_virtualization_type }}"
+echo "Timezone:             {{ motd_date_time.tz }}({{ motd_date_time.tz_offset }})"
+echo
+{% if motd_region is defined and motd_region != 'undefined'  %}
+echo "Region:               {{ motd_region }}"
+{% endif %}
+{% if motd_zone is defined and motd_zone != 'undefined' %}
+echo "Zone:                 {{ motd_zone }}"
+{% endif %}
+echo 
+{% if motd_customer is defined and motd_customer != 'undefined' %}
+echo "Customer:             {{ motd_customer }}"
+{% endif %}
+{% if motd_projects is defined and motd_projects != 'undefined' %}
+echo "Projects:             {{ motd_projects | join(',') }}"
+{% endif %}
+{% if motd_project is defined and motd_project != 'undefined' %}
+echo "Project:              {{ motd_project }}"
+{% endif %}
+echo

--- a/roles/motd/templates/etc/update-motd.d/03-sysinfo.j2
+++ b/roles/motd/templates/etc/update-motd.d/03-sysinfo.j2
@@ -1,0 +1,59 @@
+#!/bin/sh
+# {{ ansible_managed }}
+
+# System
+UPTIME=$(uptime -p)
+UPSINCE=$(uptime -s)
+USERS=$(w -h -s)
+# CPU and Load
+LOAD=$(cat /proc/loadavg | awk {'print $1 " " $2 " " $3'})
+CPUCORES=$(cat /proc/cpuinfo | grep -c processor)
+PROCESSCOUNT=$(ps aux | wc -l)
+# Memory
+TOTALMEM=$(free -m | head -n 2 | tail -n 1 | awk {'print $2'})MB
+MEMFREEREAL=$(free -m | head -n 2 | tail -n 1 | awk {'print $4'})MB
+SWAPUSAGE=$(free -m | tail -n 1 | awk {'print $3'})MB
+# Disk space
+DF=$(df -h {% for x in motd_exclude_disk_space %}-x {{ x }} {% endfor %}-l)
+
+# Kernel version
+KERNEL_VERSION=$(uname -r)
+
+echo "Load: $LOAD / CPU cores: $CPUCORES / Running proc: $PROCESSCOUNT"
+echo "$UPTIME - since $UPSINCE"
+echo
+echo "Total: $TOTALMEM / Free: $MEMFREEREAL / Swap: $SWAPUSAGE"
+echo
+echo "$DF"
+echo
+echo "Kernel Version: $KERNEL_VERSION"
+echo "Public IP: {{ lookup('ansible.builtin.url', 'https://ipv4.ip.nf/me.json', wantlist=True) | first | from_json | json_query('ip.ip') }}"
+echo
+  {% if ansible_interfaces is defined %}
+echo "Interfaces:"
+  {%   for int in ansible_interfaces %}
+  {%     if "veth" not in int %}
+  {%     if "br" not in int %}
+echo " Interface: {{ int }}"
+  {%         if hostvars[inventory_hostname]['ansible_'+int] is defined %}
+  {%           if hostvars[inventory_hostname]['ansible_'+int]['ipv4'] is defined %}
+  {%             if hostvars[inventory_hostname]['ansible_'+int]['ipv4']['address'] is defined %}
+echo "  ip: {{ hostvars[inventory_hostname]['ansible_'+int]['ipv4']['address'] }}"
+  {%               if hostvars[inventory_hostname]['ansible_'+int]['ipv4_secondaries'] is defined %}
+  {%                 for secondaries in hostvars[inventory_hostname]['ansible_'+int]['ipv4_secondaries']  %}
+echo "      {{ secondaries['address'] }}"
+  {%                 endfor %}
+  {%               endif %}
+  {%             endif %}
+  {%           endif %}
+  {%           if hostvars[inventory_hostname]['ansible_'+int]['macaddress'] is defined %}
+echo "  mac: {{ hostvars[inventory_hostname]['ansible_'+int]['macaddress'] }}"
+  {%           endif %}     
+  {%         endif %}
+  {%       endif %}
+  {%     endif %}
+  {%   endfor %}
+  {% endif %}
+echo
+echo "$DF"
+echo

--- a/roles/motd/templates/etc/update-motd.d/90-updates-available.j2
+++ b/roles/motd/templates/etc/update-motd.d/90-updates-available.j2
@@ -1,0 +1,11 @@
+#!/bin/bash
+# {{ ansible_managed }}
+# Count of all available updates
+total_updates=$(apt list --upgradable 2>/dev/null | grep -v Listing | wc -l)
+
+# Count of security updates
+security_updates=$(apt list --upgradable 2>/dev/null | grep -i security | wc -l)
+
+echo "Available updates: $total_updates"
+echo "Security updates: $security_updates"
+echo

--- a/roles/systemd_journald/defaults/main.yml
+++ b/roles/systemd_journald/defaults/main.yml
@@ -45,16 +45,16 @@ systemd_journald_rate_limit_burst: 1000
 systemd_journald_rate_limit_interval: 30s
 
 # Keeps a specified amount of disk space free (empty means default is used).
-systemd_journald_runtime_keep_free:
+systemd_journald_runtime_keep_free: ""
 
 # Maximum file size for runtime journal files (empty means default is used).
-systemd_journald_runtime_max_file_size:
+systemd_journald_runtime_max_file_size: ""
 
 # Maximum number of runtime journal files.
 systemd_journald_runtime_max_files: 100
 
 # Maximum disk space to be used for runtime journal files (empty means default is used).
-systemd_journald_runtime_max_use:
+systemd_journald_runtime_max_use: ""
 
 # Whether to seal journal files (true/false).
 systemd_journald_seal: true

--- a/roles/systemd_journald/meta/argument_specs.yml
+++ b/roles/systemd_journald/meta/argument_specs.yml
@@ -88,12 +88,10 @@ argument_specs:
       systemd_journald_runtime_keep_free:
         description: Keeps a specified amount of disk space free (empty means default is used).
         type: str
-        default: ""
 
       systemd_journald_runtime_max_file_size:
         description: Maximum file size for runtime journal files (empty means default is used).
         type: str
-        default: ""
 
       systemd_journald_runtime_max_files:
         description: Maximum number of runtime journal files.
@@ -103,7 +101,6 @@ argument_specs:
       systemd_journald_runtime_max_use:
         description: Maximum disk space to be used for runtime journal files (empty means default is used).
         type: str
-        default: ""
 
       systemd_journald_seal:
         description: Whether to seal journal files.

--- a/roles/systemd_journald/templates/etc/systemd/journald.conf.j2
+++ b/roles/systemd_journald/templates/etc/systemd/journald.conf.j2
@@ -7,37 +7,91 @@
 #  the Free Software Foundation; either version 2.1 of the License, or
 #  (at your option) any later version.
 #
-# Entries in this file show the compile time defaults.
-# You can change settings by editing this file.
-# Defaults can be restored by simply deleting this file.
+#  Entries in this file show the compile time defaults.
+#  You can change settings by editing this file.
+#  Defaults can be restored by simply deleting this file.
 #
-# See journald.conf(5) for details.
+#  See journald.conf(5) for details.
 
 [Journal]
-Compress={{ 'yes' if journald_compress else 'no' }}
-ForwardToConsole={{ 'yes' if journald_forward_to_console else 'no' }}
-ForwardToKMsg={{ 'yes' if journald_forward_to_kmsg else 'no' }}
-ForwardToSyslog={{ 'yes' if journald_forward_to_syslog else 'no' }}
-ForwardToWall={{ 'yes' if journald_forward_to_wall else 'no' }}
-LineMax={{ journald_line_max }}
-MaxFileSec={{ journald_max_file_sec }}
-MaxLevelConsole={{ journald_max_level_console }}
-MaxLevelKMsg={{ journald_max_level_kmsg }}
-MaxLevelStore={{ journald_max_level_store }}
-MaxLevelSyslog={{ journald_max_level_syslog }}
-MaxLevelWall={{ journald_max_level_wall }}
-MaxRetentionSec={{ journald_max_retention_sec }}
-RateLimitBurst={{ journald_rate_limit_burst }}
-RateLimitInterval={{ journald_rate_limit_interval }}
-RuntimeKeepFree={{ journald_runtime_keep_free }}
-RuntimeMaxFiles={{ journald_runtime_max_files }}
-RuntimeMaxFileSize={{ journald_runtime_max_file_size }}
-RuntimeMaxUse={{ journald_runtime_max_use }}
-Seal={{ 'yes' if journald_seal else 'no' }}
-SplitMode={{ journald_split_mode }}
-Storage={{ journald_storage }}
-SyncIntervalSec={{ journald_sync_interval_sec }}
-SystemKeepFree={{ journald_system_keep_free }}
-SystemMaxFiles={{ journald_system_max_files }}
-SystemMaxFileSize={{ journald_system_max_file_size }}
-SystemMaxUse={{ journald_system_max_use }}
+{% if systemd_journald_compress %}
+Compress={{ 'yes' if systemd_journald_compress else 'no' }}
+{% endif %}
+{% if systemd_journald_forward_to_console %}
+ForwardToConsole={{ 'yes' if systemd_journald_forward_to_console else 'no' }}
+{% endif %}
+{% if systemd_journald_forward_to_kmsg %}
+ForwardToKMsg={{ 'yes' if systemd_journald_forward_to_kmsg else 'no' }}
+{% endif %}
+{% if systemd_journald_forward_to_syslog %}
+ForwardToSyslog={{ 'yes' if systemd_journald_forward_to_syslog else 'no' }}
+{% endif %}
+{% if systemd_journald_forward_to_wall %}
+ForwardToWall={{ 'yes' if systemd_journald_forward_to_wall else 'no' }}
+{% endif %}
+{% if systemd_journald_line_max %}
+LineMax={{ systemd_journald_line_max }}
+{% endif %}
+{% if systemd_journald_max_file_sec %}
+MaxFileSec={{ systemd_journald_max_file_sec }}
+{% endif %}
+{% if systemd_journald_max_level_console %}
+MaxLevelConsole={{ systemd_journald_max_level_console }}
+{% endif %}
+{% if systemd_journald_max_level_kmsg %}
+MaxLevelKMsg={{ systemd_journald_max_level_kmsg }}
+{% endif %}
+{% if systemd_journald_max_level_store %}
+MaxLevelStore={{ systemd_journald_max_level_store }}
+{% endif %}
+{% if systemd_journald_max_level_syslog %}
+MaxLevelSyslog={{ systemd_journald_max_level_syslog }}
+{% endif %}
+{% if systemd_journald_max_level_wall %}
+MaxLevelWall={{ systemd_journald_max_level_wall }}
+{% endif %}
+{% if systemd_journald_max_retention_sec %}
+MaxRetentionSec={{ systemd_journald_max_retention_sec }}
+{% endif %}
+{% if systemd_journald_rate_limit_burst %}
+RateLimitBurst={{ systemd_journald_rate_limit_burst }}
+{% endif %}
+{% if systemd_journald_rate_limit_interval | default('', true) | bool %}
+RateLimitInterval={{ systemd_journald_rate_limit_interval }}
+{% endif %}
+{% if systemd_journald_runtime_keep_free | default('', true) | bool %}
+RuntimeKeepFree={{ systemd_journald_runtime_keep_free }}
+{% endif %}
+{% if systemd_journald_runtime_max_files %}
+RuntimeMaxFiles={{ systemd_journald_runtime_max_files }}
+{% endif %}
+{% if systemd_journald_runtime_max_file_size | default('', true) | bool %}
+RuntimeMaxFileSize={{ systemd_journald_runtime_max_file_size }}
+{% endif %}
+{% if systemd_journald_runtime_max_use | default('', true) | bool %}
+RuntimeMaxUse={{ systemd_journald_runtime_max_use }}
+{% endif %}
+{% if systemd_journald_seal %}
+Seal={{ 'yes' if systemd_journald_seal else 'no' }}
+{% endif %}
+{% if systemd_journald_split_mode %}
+SplitMode={{ systemd_journald_split_mode }}
+{% endif %}
+{% if systemd_journald_storage %}
+Storage={{ systemd_journald_storage }}
+{% endif %}
+{% if systemd_journald_sync_interval_sec %}
+SyncIntervalSec={{ systemd_journald_sync_interval_sec }}
+{% endif %}
+{% if systemd_journald_system_keep_free %}
+SystemKeepFree={{ systemd_journald_system_keep_free }}
+{% endif %}
+{% if systemd_journald_system_max_files %}
+SystemMaxFiles={{ systemd_journald_system_max_files }}
+{% endif %}
+{% if systemd_journald_system_max_file_size %}
+SystemMaxFileSize{{ systemd_journald_system_max_file_size }}
+{% endif %}
+{% if systemd_journald_system_max_use %}
+SystemMaxUse{{ systemd_journald_system_max_use }}
+{% endif %}


### PR DESCRIPTION
## What's Changed

- **GitHub Actions Workflow Enhancement**:
  - **Linter Workflow Enhancement (`.github/workflows/linter.yml`)**:
    - Added a new exclusion filter regex for Jinja2 templates to the linter workflow, enhancing the specificity and relevance of linting processes.

- **New Role for MOTD Configuration**:
  - **Message of the Day Role Defaults (`roles/motd/defaults/main.yml`)**:
    - Introduced comprehensive default variables for configuring the Message of the Day (MOTD), including header text, FQDN, distribution information, virtualization details, date/time, and more. This extensive list provides a highly customizable MOTD setup.

  - **MOTD Role Argument Specifications (`roles/motd/meta/argument_specs.yml`)**:
    - Created argument specifications for the MOTD role, outlining options for header text, FQDN, distribution name/version/release, virtualization role/type, date/time information, and exclusion lists for disk space checks. This specification enhances role clarity and usage documentation.

  - **MOTD Meta Information (`roles/motd/meta/main.yml`)**:
    - Defined meta information for the MOTD role, including description, author, license, minimum Ansible version, supported platforms, and tags. This metadata facilitates the role's discovery and understanding within the Ansible Galaxy community.

  - **MOTD Configuration Tasks (`roles/motd/tasks/main.yml`)**:
    - Configured tasks for setting up MOTD using templates for various sections like header, facts, system info, and updates available. These tasks leverage Ansible's templating system to dynamically generate MOTD content based on the host's state and role variables.

  - **MOTD Template Files**:
    - **Header Template (`roles/motd/templates/etc/update-motd.d/00-header.j2`)**:
      - Provided a shell script template for the MOTD header section, allowing dynamic display of custom header text.
    - **Facts Template (`roles/motd/templates/etc/update-motd.d/02-facts.j2`)**:
      - Supplied a template for displaying system facts such as FQDN, distribution info, and virtualization status.
    - **System Info Template (`roles/motd/templates/etc/update-motd.d/03-sysinfo.j2`)**:
      - Offered a detailed template for system information including uptime, users, CPU/load, memory, disk space, and kernel version.
    - **Updates Available Template (`roles/motd/templates/etc/update-motd.d/90-updates-available.j2`)**:
      - Provided a bash script template for showing available and security updates.

- **Systemd Journald Default Variables Modification** (`roles/systemd_journald/defaults/main.yml`):
  - Adjusted default variables related to runtime journal size, file count, and disk usage to enhance logging system configuration flexibility.

- **Systemd Journald Argument Specification Update** (`roles/systemd_journald/meta/argument_specs.yml`):
  - Streamlined argument specifications by removing defaults that are redundant with the system's built-in defaults, simplifying role configuration.

- **Systemd Journald Configuration Template Revision** (`roles/systemd_journald/templates/etc/systemd/journald.conf.j2`):
  - Revised the journald configuration template to dynamically include settings based on role variables, ensuring a customizable logging configuration that adapts to specific requirements.

