### PR TITLE
fix: docs

### DIFF
--- a/roles/chocolatey_packages/meta/argument_specs.yml
+++ b/roles/chocolatey_packages/meta/argument_specs.yml
@@ -202,7 +202,7 @@ argument_specs:
       chocolatey_packages_timeout:
         type: int
         description: Timeout for the installation process, default is unset.
-        default: ""
+        default: 2700
 
       chocolatey_packages_validate_certs:
         type: bool

--- a/roles/motd/README.md
+++ b/roles/motd/README.md
@@ -20,7 +20,9 @@ Variables defined in `defaults/main.yml` customize the MOTD configuration. These
 - `motd_distribution_release`: The release name of the distribution.
 - `motd_virtualization_role`: Role in virtualization (host/guest/none).
 - `motd_virtualization_type`: Type of virtualization (KVM, VirtualBox, etc.).
-- `motd_date_time`: Date and time information.
+- `motd_date_time`: Date and time information. This is a dictionary that includes the following suboptions:
+  - `tz`: The timezone setting. It uses Ansible's built-in `ansible_date_time.tz` to dynamically set the timezone based on the target host's settings.
+  - `tz_offset`: The timezone offset. It uses Ansible's built-in `ansible_date_time.tz_offset` to dynamically set the timezone offset based on the host's settings.
 - `motd_region`: Regional variable.
 - `motd_zone`: Zone variable.
 - `motd_customer`: Customer variable.

--- a/roles/motd/defaults/main.yml
+++ b/roles/motd/defaults/main.yml
@@ -26,7 +26,9 @@ motd_virtualization_role: "{{ ansible_virtualization_role }}" # Uses Ansible's b
 motd_virtualization_type: "{{ ansible_virtualization_type }}" # Uses Ansible's built-in virtualization type fact
 
 # Date and time information
-motd_date_time: "{{ ansible_date_time }}" # Uses Ansible's built-in date time fact
+motd_date_time: # Uses Ansible's built-in date time fact to populate timezone and offset
+  tz: "{{ ansible_date_time.tz }}" # Sets the timezone using Ansible's ansible_date_time fact
+  tz_offset: "{{ ansible_date_time.tz_offset }}" # Sets the timezone offset using Ansible's ansible_date_time fact
 
 # Region variable, undefined by default
 motd_region: undefined # Custom variable, default set to 'undefined'

--- a/roles/motd/meta/argument_specs.yml
+++ b/roles/motd/meta/argument_specs.yml
@@ -50,7 +50,15 @@ argument_specs:
       motd_date_time:
         description: Date and time information
         type: dict
-        default: "{{ ansible_date_time }}"
+        options:
+          tz:
+            description: Timezone of the motd_date_time
+            type: str
+            default: "{{ ansible_date_time.tz }}"
+          tz_offset:
+            description: Timezone offset of the motd_date_time
+            type: str
+            default: "{{ ansible_date_time.tz_offset }}"
 
       motd_region:
         description: Region variable


### PR DESCRIPTION
## Changed

- **Chocolatey Packages Role Update**:
  - **Argument Specification Update (`roles/chocolatey_packages/meta/argument_specs.yml`)**:
    - Modified the default value for `chocolatey_packages_timeout` from an empty string to `2700` seconds. This change ensures a sensible default timeout for the installation process, enhancing the reliability of Chocolatey package installations.

- **MOTD Role Enhancements**:
  - **README and Defaults Update (`roles/motd/README.md` & `roles/motd/defaults/main.yml`)**:
    - Expanded the `motd_date_time` variable documentation and definition to include timezone (`tz`) and timezone offset (`tz_offset`). This enhancement provides dynamic timezone setting based on the target host's settings, offering more precise date and time information in the MOTD.

  - **Argument Specifications Enhancement (`roles/motd/meta/argument_specs.yml`)**:
    - Enhanced the `motd_date_time` argument specification to include `tz` and `tz_offset` options, aligning with updates in the role's README and defaults. This update facilitates customization and clarity regarding date and time settings within the MOTD configuration.

