### PR TITLE
fix: check service

### DIFF
--- a/roles/resolv/tasks/main.yml
+++ b/roles/resolv/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Gather information about all services
+  become: true
+  ansible.builtin.service_facts:
+
 - name: Ensure stopped systemd-resolved
   ansible.builtin.include_role:
     name: arillso.system.systemd_service
@@ -6,6 +10,7 @@
     systemd_service_name: systemd-resolved
     systemd_service_enabled: false
     systemd_service_state: stopped
+  when: ansible_facts.services | dict2items | selectattr('key', 'match', '^systemd-resolved') | list | length > 0
 
 - name: Ensure resolv
   ansible.builtin.import_tasks: configure_resolv.yml


### PR DESCRIPTION
## What's Changed

- **Enhanced Service Detection Mechanism**:
  - Introduced a task to **gather information about all services** at the start of the playbook (`roles/resolv/tasks/main.yml`), ensuring that the playbook makes informed decisions based on the current state of services on the target host.
  - Modified the condition for the **Ensure stopped systemd-resolved** task to use a Jinja2 filter pipeline. This provides a **more flexible and accurate detection** of the `systemd-resolved` service, addressing an issue where the service was not correctly identified despite being present.
