### PR TITLE
feat: add rsyslog

### DIFF
--- a/roles/rsyslog/defaults/main.yml
+++ b/roles/rsyslog/defaults/main.yml
@@ -1,0 +1,56 @@
+# List of rsyslog packages to be installed
+rsyslog_packages:
+  - name: rsyslog # The main package for rsyslog
+
+# Name of the rsyslog service
+rsyslog_service: rsyslog
+
+# Main configuration for rsyslog including modules, global directives, and rules
+rsyslog_configuration:
+  modules:
+    - name: imuxsock # Module for local system logging
+      description: "provides support for local system logging"
+    - name: imklog # Module for kernel logging support
+      description: "provides kernel logging support"
+    - name: immark
+      description: "provides --MARK-- message capability"
+    - name: imudp
+      description: "provides UDP syslog reception"
+      settings:
+        input:
+          type: imudp
+          port: 514
+    - name: imtcp
+      description: "provides TCP syslog reception"
+      settings:
+        input:
+          type: imtcp
+          port: 514
+
+  global_directives:
+    file_owner: root # Default owner for log files
+    file_group: adm # Default group for log files
+    file_create_mode: "0640" # Permissions for new log files
+    dir_create_mode: "0755" # Permissions for new directories
+    umask: "0022" # Default umask for creating new files and directories
+    work_directory: "/var/spool/rsyslog" # Work directory for rsyslog
+    include_config: "/etc/rsyslog.d/*.conf" # Include additional configuration files
+
+  rules:
+    - description: "Log anything besides private authentication messages to a single log file"
+      filter: "*.*;auth,authpriv.none"
+      action: "-/var/log/syslog"
+    - description: "Log commonly used facilities to their own log file"
+      filter: "auth,authpriv.*"
+      action: "/var/log/auth.log"
+    - filter: "cron.*"
+      action: "-/var/log/cron.log"
+    - filter: "kern.*"
+      action: "/var/log/kern.log"
+    - filter: "mail.*"
+      action: "/var/log/mail.log"
+    - filter: "user.*"
+      action: "-/var/log/user.log"
+    - description: "Emergencies are sent to everybody logged in"
+      filter: "*.emerg"
+      action: ":omusrmsg:*"

--- a/roles/rsyslog/handlers/main.yml
+++ b/roles/rsyslog/handlers/main.yml
@@ -1,0 +1,18 @@
+---
+- name: Restart rsyslog
+  become: true
+  ansible.builtin.service:
+    name: "{{ rsyslog_service }}"
+    state: restarted
+
+- name: Start rsyslog
+  become: true
+  ansible.builtin.service:
+    name: "{{ rsyslog_service }}"
+    state: started
+
+- name: Enable rsyslog
+  become: true
+  ansible.builtin.service:
+    name: "{{ rsyslog_service }}"
+    enabled: true

--- a/roles/rsyslog/meta/argument_specs.yml
+++ b/roles/rsyslog/meta/argument_specs.yml
@@ -1,0 +1,87 @@
+argument_specs:
+  main:
+    short_description: Configure and manage rsyslog environment using Ansible
+    description:
+      - This spec defines the parameters for configuring rsyslog and its environment on various distributions using Ansible.
+    options:
+      rsyslog_packages:
+        type: list
+        elements: str
+        description: List of rsyslog packages to be installed.
+        default: ["rsyslog"]
+
+      rsyslog_service:
+        type: str
+        description: Name of the rsyslog service.
+        default: "rsyslog"
+
+      rsyslog_configuration:
+        type: dict
+        description: Main configuration for rsyslog including modules, global directives, and rules.
+        options:
+          modules:
+            type: list
+            elements: dict
+            description: Configuration for rsyslog modules.
+            options:
+              name:
+                type: str
+                description: Name of the module.
+              description:
+                type: str
+                description: Description of the module.
+              settings:
+                type: dict
+                description: Specific settings for the module, varies by module.
+                options:
+                  input:
+                    type: dict
+                    description: Input settings for imudp and imtcp modules.
+                    options:
+                      type:
+                        type: str
+                        description: Type of the input, e.g., imudp or imtcp.
+                      port:
+                        type: int
+                        description: Port number for UDP or TCP syslog reception.
+
+          global_directives:
+            type: dict
+            description: Global directives for file ownership, permissions, and other settings.
+            options:
+              file_owner:
+                type: str
+                description: Default owner for log files.
+              file_group:
+                type: str
+                description: Default group for log files.
+              file_create_mode:
+                type: str
+                description: Permissions for new log files.
+              dir_create_mode:
+                type: str
+                description: Permissions for new directories.
+              umask:
+                type: str
+                description: Default umask for creating new files and directories.
+              work_directory:
+                type: str
+                description: Work directory for rsyslog.
+              include_config:
+                type: str
+                description: Include additional configuration files.
+
+          rules:
+            type: list
+            elements: dict
+            description: Defines rules for logging different types of messages.
+            options:
+              description:
+                type: str
+                description: Description of what the rule does.
+              filter:
+                type: str
+                description: Filter defining which messages this rule applies to.
+              action:
+                type: str
+                description: Action to take for messages matching the filter.

--- a/roles/rsyslog/meta/main.yml
+++ b/roles/rsyslog/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  description: An Ansible role to configure rsyslog for logging management
+  author: "arillso (@arillso)"
+  license: MIT
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+        - bullseye
+    - name: Ubuntu
+      versions:
+        - focal
+        - bionic
+
+  galaxy_tags:
+    - logging
+    - rsyslog
+    - system

--- a/roles/rsyslog/tasks/main.yml
+++ b/roles/rsyslog/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Run arillso Apt Package
+  ansible.builtin.include_role:
+    name: arillso.system.apt_packages
+  vars:
+    apt_packages_list: "{{ rsyslog_packages }}"
+
+- name: Deploy main rsyslog configuration to hosts
+  become: true
+  ansible.builtin.template:
+    src: etc/rsyslog.conf.j2
+    dest: /etc/rsyslog.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - Restart rsyslog
+    - Start rsyslog
+    - Enable rsyslog

--- a/roles/rsyslog/templates/etc/rsyslog.conf.j2
+++ b/roles/rsyslog/templates/etc/rsyslog.conf.j2
@@ -1,0 +1,44 @@
+#################
+#### MODULES ####
+#################
+{% for module in rsyslog_configuration.modules %}
+module(load="{{ module.name }}") # {{ module.description }}
+{% if module.settings|default(false) %}
+  {% for key, value in module.settings.items() %}
+    {% if key == 'input' %}
+input(type="{{ value.type }}" port="{{ value.port }}")
+    {% endif %}
+  {% endfor %}
+{% endif %}
+{% endfor %}
+
+###########################
+#### GLOBAL DIRECTIVES ####
+###########################
+#
+# Set the default permissions for all log files.
+#
+$FileOwner {{ rsyslog_configuration.global_directives.file_owner }}
+$FileGroup {{ rsyslog_configuration.global_directives.file_group }}
+$FileCreateMode {{ rsyslog_configuration.global_directives.file_create_mode }}
+$DirCreateMode {{ rsyslog_configuration.global_directives.dir_create_mode }}
+$Umask {{ rsyslog_configuration.global_directives.umask }}
+
+#
+# Where to place spool and state files
+#
+$WorkDirectory {{ rsyslog_configuration.global_directives.work_directory }}
+
+#
+# Include all config files in /etc/rsyslog.d/
+#
+$IncludeConfig {{ rsyslog_configuration.global_directives.include_config }}
+
+
+###############
+#### RULES ####
+###############
+{% for rule in rsyslog_configuration.rules %}
+# Description: {{ rule.description | default("No description provided") }}
+{{ rule.filter }}                        {{ rule.action }}
+{% endfor %}


### PR DESCRIPTION
## What's Changed

- **Rsyslog Role Enhancements**:
  - **Default Variables for Rsyslog (`roles/rsyslog/defaults/main.yml`)**:
    - Added a list of `rsyslog_packages` to be installed.
    - Defined the name of the `rsyslog_service`.
    - Configured `rsyslog_configuration` with modules, global directives, and logging rules.

  - **Handlers for Rsyslog (`roles/rsyslog/handlers/main.yml`)**:
    - Added handlers to restart, start, and enable the rsyslog service.

  - **Argument Specification for Rsyslog (`roles/rsyslog/meta/argument_specs.yml`)**:
    - Defined the parameters for configuring rsyslog and its environment.

  - **Meta Information for Rsyslog (`roles/rsyslog/meta/main.yml`)**:
    - Added meta information, including description, author, license, and supported platforms.

  - **Main Tasks for Rsyslog (`roles/rsyslog/tasks/main.yml`)**:
    - Included role to install rsyslog packages.
    - Deployed main rsyslog configuration to hosts.

  - **Rsyslog Configuration Template (`roles/rsyslog/templates/etc/rsyslog.conf.j2`)**:
    - Template for rsyslog configuration, including module loading, global directives, and rules for logging.

**Full Changelog**: [https://github.com/arillso/ansible.system/compare/0.0.30...0.0.31](https://github.com/arillso/ansible.system/compare/0.0.30...0.0.31)
