### PR TITLE
# Improvements to Ansible Roles: Package Conversions and Systemd Unit Options

### DIFF
--- a/roles/maintenance/tasks/maintenance_debian.yml
+++ b/roles/maintenance/tasks/maintenance_debian.yml
@@ -8,8 +8,11 @@
   arillso.system.apt_update_info:
   register: register_update
 
-- name: Run arillso Apt Package
+- name: Convert package list and run arillso Apt Package role
   ansible.builtin.include_role:
     name: arillso.system.apt_packages
   vars:
-    apt_packages_list: "{{ register_update.packages }}"
+    apt_packages_list: >-
+      {{
+        register_update.packages | map('dict', {'name': item.package, 'version': item.available}) | list
+      }}

--- a/roles/systemd_unit/templates/unit.j2
+++ b/roles/systemd_unit/templates/unit.j2
@@ -11,8 +11,11 @@
 {{ systemd_unit_option }}
 {% endfor %}
 {% endif %}
-{% if systemd_unit_install_options | length %}
+{% if systemd_unit_install_options | length or (systemd_unit_type == 'timer' and 'WantedBy=timers.target' not in systemd_unit_install_options) %}
 [Install]
+{% if systemd_unit_type == 'timer' and 'WantedBy=timers.target' not in systemd_unit_install_options %}
+WantedBy=timers.target
+{% endif %}
 {% for systemd_unit_install_option in systemd_unit_install_options %}
 {{ systemd_unit_install_option }}
 {% endfor %}


### PR DESCRIPTION
## What's Changed

- **Improved Ansible Roles**:
  - **File**: `roles/maintenance/tasks/maintenance_debian.yml`
    - **Changes**:
      - Added conversion of the package list before running the `arillso Apt Package` role.
      - Updated task name from `Run arillso Apt Package` to `Convert package list and run arillso Apt Package role`.

  - **File**: `roles/systemd_unit/templates/unit.j2`
    - **Changes**:
      - Added condition to ensure `WantedBy=timers.target` is included for timer units.
      - Updated condition to check for `systemd_unit_install_options` length or timer type with missing `WantedBy=timers.target`.
