### PR TITLE
Add configuration option for numeric mode

### DIFF
--- a/roles/iptables/README.md
+++ b/roles/iptables/README.md
@@ -105,6 +105,10 @@ Match set for 'ipset' match. Default is not set.
 
 Flags for the 'ipset' match. Default is not set.
 
+### `iptables_rule_numeric`
+
+Skip DNS-lookup if 'TRUE'. Default is not set.
+
 ### `iptables_rule_out_interface`
 
 Outgoing interface to match (e.g., eth1). Default is not set.

--- a/roles/iptables/defaults/main.yml
+++ b/roles/iptables/defaults/main.yml
@@ -71,6 +71,9 @@ iptables_rule_match_set: "{{ omit }}"
 # Flags for the 'ipset' match
 iptables_rule_match_set_flags: "{{ omit }}"
 
+# Numeric mode
+iptables_rule_numeric: "{{ omit }}"
+
 # Outgoing interface to match (e.g., 'eth1')
 iptables_rule_out_interface: "{{ omit }}"
 

--- a/roles/iptables/meta/argument_specs.yml
+++ b/roles/iptables/meta/argument_specs.yml
@@ -228,6 +228,10 @@ argument_specs:
             description: Match criteria for the rule.
             type: str
 
+          numeric:
+            description: Skip DNS-lookup if 'TRUE'
+            type: bool
+
           policy:
             description: Set the policy for the chain to the given target.
             type: str

--- a/roles/iptables/meta/argument_specs.yml
+++ b/roles/iptables/meta/argument_specs.yml
@@ -105,6 +105,10 @@ argument_specs:
         description: Flags for the 'ipset' match.
         type: str
 
+      iptables_rule_numeric:
+        description: Skip DNS-lookup if 'TRUE'
+        type: bool
+
       iptables_rule_out_interface:
         description: Outgoing interface to match (e.g., eth1).
         type: str
@@ -227,7 +231,7 @@ argument_specs:
           policy:
             description: Set the policy for the chain to the given target.
             type: str
-            
+
           protocol:
             description: Network protocol to match (e.g., tcp, udp, icmp).
             type: str

--- a/roles/iptables/tasks/main.yml
+++ b/roles/iptables/tasks/main.yml
@@ -40,6 +40,7 @@
     iptables_rule_match: "{{ iptables_rule.match | default(omit) }}"
     iptables_rule_match_set: "{{ iptables_rule.match_set | default(omit) }}"
     iptables_rule_match_set_flags: "{{ iptables_rule.match_set_flags | default(omit) }}"
+    iptables_rule_numeric: "{{ iptables_rule.numeric | default(omit) }}"
     iptables_rule_out_interface: "{{ iptables_rule.out_interface | default(omit) }}"
     iptables_rule_policy: "{{ iptables_rule.policy | default(omit) }}"
     iptables_rule_protocol: "{{ iptables_rule.protocol | default(omit) }}"

--- a/roles/iptables/tasks/modify_iptables.yml
+++ b/roles/iptables/tasks/modify_iptables.yml
@@ -26,6 +26,7 @@
     match: "{{ iptables_rule_match | default(omit) }}"
     match_set: "{{ iptables_rule_match_set | default(omit) }}"
     match_set_flags: "{{ iptables_rule_match_set_flags | default(omit) }}"
+    numeric: "{{ iptables_rule_numeric | default(omit) }}"
     out_interface: "{{ iptables_rule_out_interface | default(omit) }}"
     policy: "{{ iptables_rule_policy | default(omit) }}"
     protocol: "{{ iptables_rule_protocol | default(omit) }}"


### PR DESCRIPTION
This PR adds a new configuration option `iptables_rules_numeric` for the `system.iptables` role.  
This exposes the `numeric` parameter of the underlying `ansible.builtin.iptables` module. (since Ansible 2.15)

[official documentation](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/iptables_module.html#parameter-numeric)

With this parameter enabled, hangs due to (reverse) DNS resolution when creating or modifying large chains or policies can be avoided. There's no impact on the functionality of the module.