### PR TITLE
fix: Fix systemd_journald_rate_limit_interval variable name

### DIFF
--- a/roles/systemd_journald/templates/etc/systemd/journald.conf.j2
+++ b/roles/systemd_journald/templates/etc/systemd/journald.conf.j2
@@ -56,8 +56,8 @@ MaxRetentionSec={{ systemd_journald_max_retention_sec }}
 {% if systemd_journald_rate_limit_burst %}
 RateLimitBurst={{ systemd_journald_rate_limit_burst }}
 {% endif %}
-{% if systemd_journald_rate_limit_interval_sec %}
-RateLimitIntervalSec={{ systemd_journald_rate_limit_interval_sec }}
+{% if systemd_journald_rate_limit_interval %}
+RateLimitIntervalSec={{ systemd_journald_rate_limit_interval }}
 {% endif %}
 {% if systemd_journald_runtime_keep_free | default('', true) | bool %}
 RuntimeKeepFree={{ systemd_journald_runtime_keep_free }}


### PR DESCRIPTION
The name of the variable in `roles/systemd_journald/defaults/main.yml` is `systemd_journald_rate_limit_interval`, and in `roles/systemd_journald/templates/etc/systemd/journald.conf.j2` is `systemd_journald_rate_limit_interval_sec`.
It causes the following error during the role run without defining any variables:
```
{"changed": false, "msg": "AnsibleUndefinedVariable: 'systemd_journald_rate_limit_interval_sec' is undefined"}
```
This PR fixes the issue above.