### PR TITLE
fix: Remove invalid defaults for three variables

### DIFF
--- a/roles/systemd_journald/templates/etc/systemd/journald.conf.j2
+++ b/roles/systemd_journald/templates/etc/systemd/journald.conf.j2
@@ -59,16 +59,16 @@ RateLimitBurst={{ systemd_journald_rate_limit_burst }}
 {% if systemd_journald_rate_limit_interval_sec %}
 RateLimitIntervalSec={{ systemd_journald_rate_limit_interval_sec }}
 {% endif %}
-{% if systemd_journald_runtime_keep_free | default('', true) | bool %}
+{% if systemd_journald_runtime_keep_free %}
 RuntimeKeepFree={{ systemd_journald_runtime_keep_free }}
 {% endif %}
 {% if systemd_journald_runtime_max_files %}
 RuntimeMaxFiles={{ systemd_journald_runtime_max_files }}
 {% endif %}
-{% if systemd_journald_runtime_max_file_size | default('', true) | bool %}
+{% if systemd_journald_runtime_max_file_size %}
 RuntimeMaxFileSize={{ systemd_journald_runtime_max_file_size }}
 {% endif %}
-{% if systemd_journald_runtime_max_use | default('', true) | bool %}
+{% if systemd_journald_runtime_max_use %}
 RuntimeMaxUse={{ systemd_journald_runtime_max_use }}
 {% endif %}
 {% if systemd_journald_seal %}


### PR DESCRIPTION
The variables `systemd_journald_runtime_keep_free`, `systemd_journald_runtime_max_file_size`, and `systemd_journald_runtime_max_use` should be strings and not booleans. The invalid default values make them unusable.