### PR TITLE
fix(firewall): improve Tailscale service dependency handling

### DIFF
--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -35,18 +35,16 @@
   become: true
   notify: Restart nftables
 
+- name: Gather service facts to check for tailscaled
+  ansible.builtin.service_facts:
+  when: ansible_facts.services is not defined
+
 - name: Check if tailscaled service exists
   ansible.builtin.set_fact:
-      _firewall_tailscale_after: >-
-          {{ ['tailscaled.service']
-             if 'tailscaled.service' in ansible_facts.get('services', {})
-             else omit }}
-      _firewall_tailscale_wants: >-
-          {{ ['tailscaled.service']
-             if 'tailscaled.service' in ansible_facts.get('services', {})
-             else omit }}
+      _firewall_tailscale_exists: >-
+          {{ 'tailscaled.service' in ansible_facts.get('services', {}) }}
 
-- name: Deploy nftables systemd override via systemd role
+- name: Deploy nftables systemd override via systemd role (with Tailscale dependency)
   ansible.builtin.include_role:
       name: arillso.system.systemd
       tasks_from: unit
@@ -59,8 +57,8 @@
                 Unit:
                     Description: nftables firewall with enhanced configuration
                     Documentation: https://wiki.nftables.org/
-                    After: "{{ _firewall_tailscale_after }}"
-                    Wants: "{{ _firewall_tailscale_wants }}"
+                    After: "{{ ['tailscaled.service'] }}"
+                    Wants: "{{ ['tailscaled.service'] }}"
                 Service:
                     Type: oneshot
                     RemainAfterExit: "yes"
@@ -71,6 +69,32 @@
                     ExecStop: /usr/sbin/nft flush ruleset
                 Install:
                     WantedBy: multi-user.target
+  when: _firewall_tailscale_exists | bool
+
+- name: Deploy nftables systemd override via systemd role (without Tailscale dependency)
+  ansible.builtin.include_role:
+      name: arillso.system.systemd
+      tasks_from: unit
+  vars:
+      systemd_unit_path: /etc/systemd/system/nftables.service.d
+      systemd_units:
+          - name: override.conf
+            state: present
+            unit:
+                Unit:
+                    Description: nftables firewall with enhanced configuration
+                    Documentation: https://wiki.nftables.org/
+                Service:
+                    Type: oneshot
+                    RemainAfterExit: "yes"
+                    ExecStart:
+                        - ""
+                        - /usr/sbin/nft -f /etc/nftables.conf
+                    ExecReload: /usr/sbin/nft -f /etc/nftables.conf
+                    ExecStop: /usr/sbin/nft flush ruleset
+                Install:
+                    WantedBy: multi-user.target
+  when: not (_firewall_tailscale_exists | bool)
 
 - name: Enable and start nftables service via systemd role
   ansible.builtin.include_role:


### PR DESCRIPTION
## Problem

The previous implementation used `omit` to conditionally add Tailscale dependencies (After/Wants) to the nftables systemd unit. This could cause issues with systemd unit validation when the service doesn't exist.

## Solution

- Add explicit `service_facts` gather to ensure service information is available
- Split nftables systemd override into two conditional tasks:
  - One with Tailscale dependencies (when service exists)
  - One without Tailscale dependencies (when service doesn't exist)
- Use boolean fact `_firewall_tailscale_exists` for cleaner conditionals

## Changes

- Added service_facts gather task
- Split systemd unit configuration into two separate include_role calls
- Simplified fact checking logic
- Improved task naming for clarity

## Testing

This ensures the nftables service configuration is valid whether Tailscale is installed or not.