### PR TITLE
fix(docs): add missing filter docs and update README for 1.0.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,39 @@ Key roles:
 
 ### Release Process
 
-1. Update CHANGELOG.md with version and changes
-2. Create git tag with version (e.g., v1.0.0)
-3. Push tag to trigger Galaxy publish workflow
+**IMPORTANT: Always update CHANGELOG.md before releasing!**
+
+1. **Update CHANGELOG.md** (REQUIRED - DO NOT SKIP!)
+   - Add new version section (e.g., `## [1.0.1] - 2026-01-14`)
+   - Document all changes under appropriate sections:
+     - Added - new features
+     - Changed - changes in existing functionality
+     - Deprecated - soon-to-be removed features
+     - Removed - removed features
+     - Fixed - bug fixes
+     - Security - security fixes
+   - Move items from `## [Unreleased]` to the new version section
+
+2. **Update galaxy.yml version**
+   - Change `version:` field to match the new release version
+
+3. **Create and push git tag**
+   - Use version without 'v' prefix (e.g., `1.0.1` not `v1.0.1`)
+   - Follow Ansible Collections best practice (no v prefix)
+   - Command: `git tag 1.0.1 && git push origin 1.0.1`
+
+4. **Automated workflow triggers**
+   - Tag push automatically triggers `publish.yml` workflow
+   - Workflow extracts changelog for the version
+   - Publishes to Ansible Galaxy
+   - Creates GitHub Release with changelog notes
+
+**Release Checklist:**
+- [ ] CHANGELOG.md updated with new version
+- [ ] galaxy.yml version updated
+- [ ] All CI tests passing
+- [ ] README.md reflects current state (if needed)
+- [ ] Git tag created and pushed (without v prefix)
 
 ## Do Not
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-01-14
+
+### Fixed
+
+- Added missing filter documentation for `from_toml` and `to_nice_toml`
+- Resolves ansible-doc errors during Galaxy import
+
 ## [1.0.0] - 2026-01-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -4,54 +4,92 @@
 
 ## Description
 
-This is an Ansible collection that installs and then configures various system.
+This Ansible collection provides comprehensive system configuration and management capabilities for Linux servers. It includes unified roles for access control, package management, network configuration, firewall setup, logging, and system tuning.
 
 ## Roles
 
-- [apt_cache](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/apt_cache)
-- [apt_repositories](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/apt_repositories)
-- [iptables](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/iptables)
-- [packages](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/packages)
-- [ssh](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/ssh)
-- [systemd_service](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/systemd_service)
-- [yum_repositories](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/yum_repositories)
-- [apt_configuration](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/apt_configuration)
-- [chocolatey_packages](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/chocolatey_packages)
-- [dnf_packages](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/dnf_packages)
-- [environment](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/environment)
-- [maintenance](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/maintenance)
-- [netplan](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/netplan)
-- [reboot](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/reboot)
-- [sudoers](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/sudoers)
-- [systemd_unit](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/systemd_unit)
-- [apt_keys](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/apt_keys)
-- [logrotate](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/logrotate)
-- [pip](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/pip)
-- [resolv](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/resolv)
-- [sysctl](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/sysctl)
-- [systemd_journald](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/systemd_journald)
-- [timezone](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/timezone)
-- [users](https://galaxy.ansible.com/ui/repo/published/arillso/system/content/role/users)
+### Core System Roles
+
+- **[access](roles/access)** - User/group/SSH/sudo management
+- **[ansible](roles/ansible)** - Ansible automation with systemd timer
+- **[facts](roles/facts)** - Extended system facts (cloud, container, security)
+- **[packages](roles/packages)** - Package management with APT, DNF, unattended upgrades
+- **[python](roles/python)** - Python and pip management
+- **[ready](roles/ready)** - System readiness checks
+- **[shell](roles/shell)** - Shell environment and MOTD configuration
+
+### Infrastructure Roles
+
+- **[firewall](roles/firewall)** - NFTables firewall configuration
+- **[logging](roles/logging)** - Log management (rsyslog, logrotate)
+- **[network](roles/network)** - Network configuration (netplan, resolv)
+- **[systemd](roles/systemd)** - Systemd service/unit/journald management
+
+### Advanced Roles
+
+- **[bitwarden_secrets](roles/bitwarden_secrets)** - Bitwarden CLI secret management
+- **[thermal](roles/thermal)** - CPU thermal management
+- **[tuning](roles/tuning)** - System performance tuning (CPU, IO, network, swap)
 
 ## Plugins
 
-plugins/lookup:
+### Lookup Plugins
 
-- github_latest_release.py
+- **environment_files** - Curate file lists based on patterns
+- **github_latest_release** - Fetch latest GitHub release version
 
-plugins/modules:
+### Modules
 
-- apt_update_info.py
-- reboot_info.py
+- **apt_update_info** - Retrieve list of updatable APT packages
+- **reboot_info** - Check if system requires reboot
+
+### Filter Plugins
+
+- **from_toml** - Convert TOML string to dictionary
+- **to_toml** - Convert dictionary to TOML string
+- **to_nice_toml** - Convert dictionary to nicely formatted TOML
+- **to_nftables_hierarchy** - Generate nftables rule hierarchy
+- **to_nftables_rule** - Generate nftables rule
+- **to_nftables_ports** - Generate nftables port rules
+
+## Installation
+
+```bash
+ansible-galaxy collection install arillso.system
+```
+
+## Requirements
+
+- Ansible 2.16 or higher
+- Python 3.11 or higher
+- Dependencies:
+  - ansible.posix >= 2.0.0
+  - community.general >= 9.0.0
+  - community.crypto >= 2.0.0
+
+## Documentation
+
+Full documentation is available at: https://guide.arillso.io/collections/arillso/system/
+
+## Breaking Changes in 1.0.0
+
+Version 1.0.0 introduces a major restructuring. Many roles have been removed and consolidated:
+
+- `users`, `groups`, `ssh`, `sudoers` → **access**
+- `apt_*`, `dnf_packages`, `chocolatey_packages` → **packages**
+- `iptables` → **firewall**
+- `rsyslog`, `logrotate` → **logging**
+- `netplan`, `resolv` → **network**
+- `systemd_journald`, `systemd_service`, `systemd_unit` → **systemd**
+- `pip` → **python**
+- `motd` → **shell**
+
+See [CHANGELOG.md](CHANGELOG.md) for migration guidance.
 
 ## License
 
-<!-- markdownlint-disable -->
-
 This project is under the MIT License. See the [LICENSE](LICENSE) file for the full license text.
-
-<!-- markdownlint-enable -->
 
 ## Copyright
 
-(c) 2023, Arillso
+(c) 2024-2026, Arillso

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: system
-version: 1.0.0
+version: 1.0.1
 readme: README.md
 
 authors:

--- a/plugins/filter/from_toml.yml
+++ b/plugins/filter/from_toml.yml
@@ -1,0 +1,31 @@
+---
+DOCUMENTATION:
+  name: from_toml
+  author: arillso (@arillso)
+  version_added: "1.0.0"
+  short_description: Convert TOML string to dictionary
+  description:
+    - Converts a TOML-formatted string into a Python dictionary.
+    - Uses tomllib (Python 3.11+) or tomli package for parsing.
+  positional: _input
+  options:
+    _input:
+      description: TOML string to parse
+      type: str
+      required: true
+
+EXAMPLES: |
+  # Parse TOML string
+  - name: Parse TOML configuration
+    ansible.builtin.set_fact:
+      config: "{{ toml_string | arillso.system.from_toml }}"
+
+  # Parse TOML from file
+  - name: Load TOML config file
+    ansible.builtin.set_fact:
+      app_config: "{{ lookup('file', 'config.toml') | arillso.system.from_toml }}"
+
+RETURN:
+  _value:
+    description: Python dictionary representation of the TOML input
+    type: dict

--- a/plugins/filter/to_nice_toml.yml
+++ b/plugins/filter/to_nice_toml.yml
@@ -1,0 +1,33 @@
+---
+DOCUMENTATION:
+  name: to_nice_toml
+  author: arillso (@arillso)
+  version_added: "1.0.0"
+  short_description: Convert dictionary to nicely formatted TOML
+  description:
+    - Converts a Python dictionary into a nicely formatted TOML string.
+    - Handles nested dictionaries and arrays with proper indentation.
+    - Formats date-time values correctly as YYYY-MM-DDTHH:MM:SSZ.
+  positional: _input
+  options:
+    _input:
+      description: Dictionary to convert to TOML
+      type: dict
+      required: true
+
+EXAMPLES: |
+  # Convert dict to nicely formatted TOML
+  - name: Generate TOML config
+    ansible.builtin.copy:
+      content: "{{ config_dict | arillso.system.to_nice_toml }}"
+      dest: /etc/app/config.toml
+
+  # Format complex nested structure
+  - name: Create formatted TOML
+    ansible.builtin.set_fact:
+      toml_output: "{{ complex_data | arillso.system.to_nice_toml }}"
+
+RETURN:
+  _value:
+    description: Nicely formatted TOML string representation of the input dictionary
+    type: str


### PR DESCRIPTION
## Fixes

- Add missing filter documentation for `from_toml` and `to_nice_toml`
- Update README.md with current roles and plugins
- Remove references to deprecated/removed roles
- Add breaking changes section for 1.0.0

## Changes

- Created `plugins/filter/from_toml.yml`
- Created `plugins/filter/to_nice_toml.yml`
- Updated README with 1.0.0 structure
- Bump version to 1.0.1

Resolves ansible-doc errors during Galaxy import.