### PR TITLE
feat(ansible): add automatic Galaxy requirements installation

### DIFF
--- a/roles/ansible/defaults/main.yml
+++ b/roles/ansible/defaults/main.yml
@@ -17,6 +17,10 @@ ansible_inventory: "inventory/hosts"
 ansible_extra_args: ""
 ansible_host_limit: "{{ inventory_hostname }}"
 
+ansible_install_collections: true
+ansible_install_roles: false
+ansible_requirements_file: "requirements.yml"
+
 # Systemd Timer Configuration
 ansible_schedule: "*:0/15"
 ansible_random_delay: 300

--- a/roles/ansible/meta/argument_specs.yml
+++ b/roles/ansible/meta/argument_specs.yml
@@ -51,6 +51,27 @@ argument_specs:
                 type: str
                 default: ""
 
+            ansible_install_collections:
+                description: >-
+                    Install collections from requirements.yml before playbook execution.
+                    Note: ansible-pull does NOT automatically install collections, so this ensures
+                    dependencies are available in both pull and playbook modes.
+                type: bool
+                default: true
+
+            ansible_install_roles:
+                description: >-
+                    Install roles from requirements.yml before playbook execution.
+                    Note: ansible-pull does NOT automatically install roles, so this ensures
+                    dependencies are available in both pull and playbook modes.
+                type: bool
+                default: false
+
+            ansible_requirements_file:
+                description: Path to requirements file (relative to repository root)
+                type: str
+                default: requirements.yml
+
             ansible_schedule:
                 description: Systemd timer schedule (OnCalendar format)
                 type: str

--- a/roles/ansible/tasks/timer.yml
+++ b/roles/ansible/tasks/timer.yml
@@ -58,6 +58,43 @@
           {{ ansible_checkout_dir }}/repo/{{ ansible_playbook }}
   when: ansible_mode == 'playbook'
 
+- name: Build galaxy collection install command
+  ansible.builtin.set_fact:
+      ansible_role_galaxy_collections_cmd: >-
+          {% if ansible_install_method == 'pipx' -%}
+          {{ ansible_pipx_bin }}/ansible-galaxy{%- else -%}
+          /usr/bin/ansible-galaxy{%- endif %}
+          collection install
+          -r {{ ansible_checkout_dir }}/repo/{{ ansible_requirements_file }}
+          --force
+  when: ansible_install_collections | bool
+
+- name: Build galaxy role install command
+  ansible.builtin.set_fact:
+      ansible_role_galaxy_roles_cmd: >-
+          {% if ansible_install_method == 'pipx' -%}
+          {{ ansible_pipx_bin }}/ansible-galaxy{%- else -%}
+          /usr/bin/ansible-galaxy{%- endif %}
+          role install
+          -r {{ ansible_checkout_dir }}/repo/{{ ansible_requirements_file }}
+          --force
+  when: ansible_install_roles | bool
+
+- name: Build ExecStartPre commands for pull mode
+  ansible.builtin.set_fact:
+      ansible_role_exec_start_pre_pull: >-
+          {{ (ansible_install_collections | bool | ternary([ansible_role_galaxy_collections_cmd], [])) +
+             (ansible_install_roles | bool | ternary([ansible_role_galaxy_roles_cmd], [])) }}
+  when: ansible_mode == 'pull'
+
+- name: Build ExecStartPre commands for playbook mode
+  ansible.builtin.set_fact:
+      ansible_role_exec_start_pre_playbook: >-
+          {{ ['/usr/bin/git -C ' + ansible_checkout_dir + '/repo pull origin ' + ansible_branch] +
+             (ansible_install_collections | bool | ternary([ansible_role_galaxy_collections_cmd], [])) +
+             (ansible_install_roles | bool | ternary([ansible_role_galaxy_roles_cmd], [])) }}
+  when: ansible_mode == 'playbook'
+
 - name: Build environment variables for systemd
   ansible.builtin.set_fact:
       ansible_role_env_list: >-
@@ -85,9 +122,8 @@
                     Type: oneshot
                     EnvironmentFile: "-/etc/ansible/ansible.env"
                     ExecStartPre: >-
-                        {{ omit if ansible_mode == 'pull'
-                           else '/usr/bin/git -C ' + ansible_checkout_dir +
-                                '/repo pull origin ' + ansible_branch }}
+                        {{ ansible_role_exec_start_pre_pull if ansible_mode == 'pull'
+                           else ansible_role_exec_start_pre_playbook }}
                     ExecStart: >-
                         {{ ansible_role_exec_start_pull if ansible_mode == 'pull'
                            else ansible_role_exec_start_playbook }}


### PR DESCRIPTION
Add support for automatic installation of collections and roles from requirements.yml in both ansible-pull and ansible-playbook modes.

Changes:
- Add ansible_install_collections (default: true) to enable collection installation
- Add ansible_install_roles (default: false) to enable role installation
- Add ansible_requirements_file variable to specify requirements file path
- Install dependencies via ExecStartPre in systemd service
- Support both pull and playbook execution modes

Note: ansible-pull does NOT automatically install collections/roles from requirements.yml (see GitHub issues #76535 and #70309). This implementation ensures dependencies are available before playbook execution in both modes.

Pull mode execution order:
1. ansible-galaxy collection install (if enabled)
2. ansible-galaxy role install (if enabled)
3. ansible-pull

Playbook mode execution order:
1. git pull
2. ansible-galaxy collection install (if enabled)
3. ansible-galaxy role install (if enabled)
4. ansible-playbook