### PR TITLE
chore: release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2026-01-16
+
+### Added
+
+- Automatic Galaxy requirements installation for ansible role in both pull and playbook modes
+- New variables `ansible_install_collections` (default: true), `ansible_install_roles` (default: false), and `ansible_requirements_file`
+- Collections and roles are now automatically installed before playbook execution via systemd ExecStartPre
+- GitHub issue templates (bug report, feature request, documentation)
+- GitHub pull request template with contribution checklist
+
+### Fixed
+
+- ansible-pull does not automatically install collections/roles from requirements.yml
+  (addresses upstream issues #76535 and #70309)
+
 ## [1.0.1] - 2026-01-14
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: system
-version: 1.0.1
+version: 1.0.2
 readme: README.md
 
 authors:


### PR DESCRIPTION
## Summary

Prepare release 1.0.2 with new features and improvements.

## Changes

### Added

- **Automatic Galaxy requirements installation** for ansible role in both pull and playbook modes
  - New variable `ansible_install_collections` (default: true)
  - New variable `ansible_install_roles` (default: false)
  - New variable `ansible_requirements_file` (default: requirements.yml)
  - Collections and roles are now automatically installed before playbook execution via systemd ExecStartPre

- **GitHub Templates** for better contribution workflow
  - Bug report template
  - Feature request template
  - Documentation template
  - Pull request template with checklist

### Fixed

- Resolves issue where ansible-pull does not automatically install collections/roles from requirements.yml
  (addresses upstream Ansible issues #76535 and #70309)

## Version Updates

- CHANGELOG.md updated with 1.0.2 release notes
- galaxy.yml version bumped to 1.0.2

## Release Process

After this PR is merged:
1. Create git tag: `git tag 1.0.2 && git push origin 1.0.2`
2. GitHub workflow will automatically:
   - Publish to Ansible Galaxy
   - Create GitHub Release with changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)