### PR TITLE
fix(ansible): use environment variables for pipx configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-01-16
+
+### Fixed
+
+- Fix pipx module usage by replacing unsupported parameters (pipx_home, global_bin_dir)
+  with environment variables (PIPX_HOME, PIPX_BIN_DIR)
+- Resolves error: "Unsupported parameters for (community.general.pipx) module"
+
 ## [1.0.2] - 2026-01-16
 
 ### Added

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: system
-version: 1.0.2
+version: 1.0.3
 readme: README.md
 
 authors:

--- a/roles/ansible/tasks/install.yml
+++ b/roles/ansible/tasks/install.yml
@@ -34,8 +34,9 @@
             name: "ansible{{ ('==' + ansible_package_version) if ansible_package_version else '' }}"
             state: install
             install_deps: true
-            pipx_home: "{{ ansible_pipx_home }}"
-            global_bin_dir: "{{ ansible_pipx_bin }}"
+        environment:
+            PIPX_HOME: "{{ ansible_pipx_home }}"
+            PIPX_BIN_DIR: "{{ ansible_pipx_bin }}"
         become: true
 
       - name: Build inject package list
@@ -51,8 +52,9 @@
             name: ansible
             state: inject
             inject_packages: "{{ ansible_role_inject_packages }}"
-            pipx_home: "{{ ansible_pipx_home }}"
-            global_bin_dir: "{{ ansible_pipx_bin }}"
+        environment:
+            PIPX_HOME: "{{ ansible_pipx_home }}"
+            PIPX_BIN_DIR: "{{ ansible_pipx_bin }}"
         become: true
         when: ansible_role_inject_packages | length > 0
 


### PR DESCRIPTION
## Summary

Hotfix for pipx module error caused by unsupported parameters.

## Problem

The ansible role was failing with the error:
```
Unsupported parameters for (community.general.pipx) module: global_bin_dir, pipx_home
```

## Root Cause

The `community.general.pipx` module does not support `pipx_home` and `global_bin_dir` as direct parameters. Instead, it honors environment variables.

## Solution

Replace module parameters with environment variables:
- `pipx_home` → `PIPX_HOME` environment variable
- `global_bin_dir` → `PIPX_BIN_DIR` environment variable

## Changes

- Updated `roles/ansible/tasks/install.yml` to use environment variables
- Applied to both `install` and `inject` tasks
- Updated CHANGELOG.md for version 1.0.3
- Updated galaxy.yml to version 1.0.3

## Testing

- ✅ ansible-lint passed without errors

## Release

This is a hotfix release (1.0.3). After merge, the release tag will be created automatically.

## References

- [community.general.pipx module documentation](https://docs.ansible.com/projects/ansible/latest/collections/community/general/pipx_module.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)