### PR TITLE
fix(ansible): improve systemd ExecStartPre reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-01-16
+
+### Fixed
+
+- Add `-` prefix to systemd ExecStartPre commands to allow failure without stopping service
+- Fix environment variable building by replacing dict2items with keys/zip/values
+  for better compatibility
+- Ensures git pull and galaxy install failures don't prevent playbook execution
+
 ## [1.0.3] - 2026-01-16
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: system
-version: 1.0.3
+version: 1.0.4
 readme: README.md
 
 authors:

--- a/roles/ansible/tasks/timer.yml
+++ b/roles/ansible/tasks/timer.yml
@@ -61,7 +61,7 @@
 - name: Build galaxy collection install command
   ansible.builtin.set_fact:
       ansible_role_galaxy_collections_cmd: >-
-          {% if ansible_install_method == 'pipx' -%}
+          -{% if ansible_install_method == 'pipx' -%}
           {{ ansible_pipx_bin }}/ansible-galaxy{%- else -%}
           /usr/bin/ansible-galaxy{%- endif %}
           collection install
@@ -72,7 +72,7 @@
 - name: Build galaxy role install command
   ansible.builtin.set_fact:
       ansible_role_galaxy_roles_cmd: >-
-          {% if ansible_install_method == 'pipx' -%}
+          -{% if ansible_install_method == 'pipx' -%}
           {{ ansible_pipx_bin }}/ansible-galaxy{%- else -%}
           /usr/bin/ansible-galaxy{%- endif %}
           role install
@@ -90,7 +90,7 @@
 - name: Build ExecStartPre commands for playbook mode
   ansible.builtin.set_fact:
       ansible_role_exec_start_pre_playbook: >-
-          {{ ['/usr/bin/git -C ' + ansible_checkout_dir + '/repo pull origin ' + ansible_branch] +
+          {{ ['-/usr/bin/git -C ' + ansible_checkout_dir + '/repo pull origin ' + ansible_branch] +
              (ansible_install_collections | bool | ternary([ansible_role_galaxy_collections_cmd], [])) +
              (ansible_install_roles | bool | ternary([ansible_role_galaxy_roles_cmd], [])) }}
   when: ansible_mode == 'playbook'
@@ -98,8 +98,7 @@
 - name: Build environment variables for systemd
   ansible.builtin.set_fact:
       ansible_role_env_list: >-
-          {{ ansible_environment | dict2items |
-             map('community.general.dict_kv', 'key', 'value') |
+          {{ ansible_environment.keys() | zip(ansible_environment.values()) |
              map('join', '=') | list }}
   when: ansible_environment | length > 0
 


### PR DESCRIPTION
## Summary

Improve systemd service reliability by adding failure tolerance and fixing environment variable handling.

## Changes

### 1. Add `-` Prefix to ExecStartPre Commands

The `-` prefix in systemd unit files allows commands to fail without stopping the service:

```yaml
# Before (failure stops service):
ExecStartPre=/usr/bin/git pull

# After (failure is tolerated):
ExecStartPre=-/usr/bin/git pull
```

This is especially important for:
- **Git pull failures**: Network issues, authentication problems, repo unavailable
- **Galaxy install failures**: Missing requirements.yml, network timeouts, package not found

With this fix, the ansible automation continues even if pre-commands fail.

### 2. Fix Environment Variable Building

Replace `dict2items` filter with `keys()/zip()/values()` for better Jinja2 compatibility:

```yaml
# Before:
ansible_environment | dict2items | map('community.general.dict_kv', 'key', 'value')

# After:
ansible_environment.keys() | zip(ansible_environment.values())
```

## Testing

- ✅ ansible-lint passed without errors

## Version

- Updated CHANGELOG.md for version 1.0.4
- Updated galaxy.yml to version 1.0.4

## Impact

This is a reliability improvement that makes the ansible automation more resilient to transient failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)