### PR TITLE
docs: improve documentation and fix Sphinx warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5] - 2026-01-16
+
+### Fixed
+
+- Fix Sphinx documentation build warning for to_toml filter examples
+- Convert bare Jinja2 expressions to valid YAML playbook tasks in filter documentation
+
+### Changed
+
+- Improve README.md formatting and installation instructions
+- Add requirements.yml installation example to README
+- Clarify dependencies section in README
+
 ## [1.0.4] - 2026-01-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible Collection: arillso.system
 
-[![LICENSE](https://img.shields.io/github/license/mashape/apistatus.svg?style=popout-square)](LICENSE) [![Ansible Galaxy](http://img.shields.io/badge/ansible--galaxy-arillso.system-blue.svg?style=popout-square)](https://galaxy.ansible.com/arillso/system)
+[![license](https://img.shields.io/github/license/mashape/apistatus.svg?style=popout-square)](LICENSE) [![Ansible Galaxy](http://img.shields.io/badge/ansible--galaxy-arillso.system-blue.svg?style=popout-square)](https://galaxy.ansible.com/arillso/system)
 
 ## Description
 
@@ -54,37 +54,40 @@ This Ansible collection provides comprehensive system configuration and manageme
 
 ## Installation
 
+Install this collection from Ansible Galaxy:
+
 ```bash
 ansible-galaxy collection install arillso.system
 ```
 
+Or add it to your `requirements.yml`:
+
+```yaml
+---
+collections:
+    - name: arillso.system
+      version: ">=1.0.0"
+```
+
 ## Requirements
 
-- Ansible 2.16 or higher
-- Python 3.11 or higher
-- Dependencies:
-  - ansible.posix >= 2.0.0
-  - community.general >= 9.0.0
-  - community.crypto >= 2.0.0
+- Ansible >= 2.16
+- Python >= 3.11
+
+## Dependencies
+
+- ansible.posix >= 2.0.0
+- community.general >= 9.0.0
+- community.crypto >= 2.0.0
 
 ## Documentation
 
-Full documentation is available at: https://guide.arillso.io/collections/arillso/system/
+Full documentation is available at:
+<https://guide.arillso.io/collections/arillso/system/>
 
-## Breaking Changes in 1.0.0
+**Breaking Changes in 1.0.0:**
 
-Version 1.0.0 introduces a major restructuring. Many roles have been removed and consolidated:
-
-- `users`, `groups`, `ssh`, `sudoers` → **access**
-- `apt_*`, `dnf_packages`, `chocolatey_packages` → **packages**
-- `iptables` → **firewall**
-- `rsyslog`, `logrotate` → **logging**
-- `netplan`, `resolv` → **network**
-- `systemd_journald`, `systemd_service`, `systemd_unit` → **systemd**
-- `pip` → **python**
-- `motd` → **shell**
-
-See [CHANGELOG.md](CHANGELOG.md) for migration guidance.
+Version 1.0.0 introduces a major restructuring. Many roles have been removed and consolidated. See [CHANGELOG.md](CHANGELOG.md) for migration guidance.
 
 ## License
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: system
-version: 1.0.4
+version: 1.0.5
 readme: README.md
 
 authors:

--- a/plugins/filter/to_toml.yml
+++ b/plugins/filter/to_toml.yml
@@ -20,13 +20,22 @@ DOCUMENTATION:
 
 EXAMPLES: |
     # Convert dictionary to TOML string
-    {{ config_dict | arillso.system.to_toml }}
+    - name: Generate TOML configuration
+      ansible.builtin.set_fact:
+        toml_output: "{{ config_dict | arillso.system.to_toml }}"
 
-    # Example with data
-    {{ {'title': 'Example', 'owner': {'name': 'Admin'}} | arillso.system.to_toml }}
+    # Example with inline dictionary
+    - name: Convert inline dict to TOML
+      ansible.builtin.debug:
+        msg: "{{ {'title': 'Example', 'owner': {'name': 'Admin'}} | arillso.system.to_toml }}"
 
     # Use in template to create TOML config file
-    {{ application_config | arillso.system.to_toml }}
+    - name: Create TOML config file
+      ansible.builtin.template:
+        src: config.toml.j2
+        dest: /etc/app/config.toml
+      vars:
+        toml_content: "{{ application_config | arillso.system.to_toml }}"
 
 RETURN:
     _value:


### PR DESCRIPTION
## Summary

Improve documentation quality and fix Sphinx build warnings for release 1.0.5.

## Problem

Sphinx documentation build was generating warnings:
```
WARNING: Lexing literal_block "{{ config_dict | arillso.system.to_toml }}" 
as "yaml+jinja" resulted in an error at token: ' '. Retrying in relaxed mode.
```

## Changes

### Filter Documentation
- **Fixed to_toml.yml examples**: Converted bare Jinja2 expressions to valid YAML playbook tasks
  - Before: `{{ config_dict | arillso.system.to_toml }}`
  - After: Proper task examples with `set_fact`, `debug`, and `template` modules

### README Improvements
- Improved formatting and structure
- Added `requirements.yml` installation example
- Clarified dependencies section
- Better organization of installation instructions

### Version Update
- Updated CHANGELOG.md for version 1.0.5
- Updated galaxy.yml to version 1.0.5

## Testing

- ✅ ansible-lint passed
- ✅ YAML syntax valid
- ✅ Examples follow Ansible best practices

## Impact

- Cleaner Sphinx documentation builds without warnings
- Better user documentation with complete playbook examples
- Easier installation process with requirements.yml example

🤖 Generated with [Claude Code](https://claude.com/claude-code)