### PR TITLE
ci: migrate to reusable workflows and add Claude integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,210 +3,34 @@ name: Continuous Integration
 
 on:
     push:
-        branches: [main, master]
+        branches: [main]
     pull_request:
-        branches: [main, master]
+        branches: [main]
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}
     cancel-in-progress: true
 
+permissions:
+    contents: read
+    security-events: write
+    actions: read
+    pull-requests: read
+    issues: read
+    id-token: write
+
 jobs:
-    # Ansible-specific linting
-    ansible-lint:
-        name: Ansible Lint
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+    ci:
+        uses: arillso/.github/.github/workflows/ci-ansible-collection.yml@2026-03-08
+        with:
+            collection_namespace: arillso
+            collection_name: system
 
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-              with:
-                  python-version: "3.11"
-                  cache: "pip"
+    security-secrets:
+        uses: arillso/.github/.github/workflows/security-secrets.yml@2026-03-08
 
-            - name: Install ansible-lint
-              run: pip install ansible-lint ansible-core
-
-            - name: Run ansible-lint
-              run: ansible-lint --force-color
-
-    # YAML linting
-    yaml-lint:
-        name: YAML Lint
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-              with:
-                  python-version: "3.11"
-
-            - name: Install yamllint
-              run: pip install yamllint
-
-            - name: Run yamllint
-              run: yamllint .
-
-    # Python linting and formatting
-    python-lint:
-        name: Python Lint
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-              with:
-                  python-version: "3.11"
-                  cache: "pip"
-
-            - name: Install linting tools
-              run: |
-                  pip install ruff pylint black isort
-                  pip install ansible-core  # For filter plugin imports
-
-            - name: Run ruff
-              run: ruff check plugins/ --output-format=github
-              continue-on-error: true
-
-            - name: Run black (check only)
-              run: black --check --diff plugins/
-              continue-on-error: true
-
-            - name: Run isort (check only)
-              run: isort --check-only --diff plugins/
-              continue-on-error: true
-
-            - name: Run pylint
-              run: pylint plugins/**/*.py
-              continue-on-error: true
-
-    # Markdown linting
-    markdown-lint:
-        name: Markdown Lint
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-            - name: Run markdownlint
-              uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101 # v22
-              with:
-                  globs: "**/*.md"
-              continue-on-error: true
-
-    # Security scanning
-    security-scan:
-        name: Security Scan
-        runs-on: ubuntu-latest
-        permissions:
-            security-events: write
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-            - name: Run Trivy vulnerability scanner
-              uses: aquasecurity/trivy-action@master
-              with:
-                  scan-type: "fs"
-                  scan-ref: "."
-                  format: "sarif"
-                  output: "trivy-results.sarif"
-              continue-on-error: true
-
-            - name: Upload Trivy results to GitHub Security
-              uses: github/codeql-action/upload-sarif@6bc82e05fd0ea64601dd4b465378bbcf57de0314 # v4
-              with:
-                  sarif_file: "trivy-results.sarif"
-              if: always()
-              continue-on-error: true
-
-    # Collection sanity tests
-    sanity-test:
-        name: Sanity Tests
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                include:
-                    - ansible-version: "stable-2.16"
-                      python-version: "3.11"
-                    - ansible-version: "stable-2.17"
-                      python-version: "3.11"
-                    - ansible-version: "devel"
-                      python-version: "3.12"
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-              with:
-                  path: ansible_collections/arillso/system
-
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-              with:
-                  python-version: "${{ matrix.python-version }}"
-
-            - name: Install Ansible
-              run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible-version }}.tar.gz --disable-pip-version-check
-
-            - name: Install collection dependencies
-              run: pip install -r requirements.txt
-              working-directory: ansible_collections/arillso/system
-
-            - name: Run sanity tests
-              run: ansible-test sanity --docker --color --python ${{ matrix.python-version }}
-              working-directory: ansible_collections/arillso/system
-
-    # Collection integration tests (if you have them)
-    integration-test:
-        name: Integration Tests
-        runs-on: ubuntu-latest
-        if: false # Enable when integration tests are available
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-              with:
-                  path: ansible_collections/arillso/system
-
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-              with:
-                  python-version: "3.11"
-
-            - name: Install Ansible
-              run: pip install ansible-core
-
-            - name: Run integration tests
-              run: ansible-test integration --docker --color
-              working-directory: ansible_collections/arillso/system
-
-    # Build and validate collection
-    build:
-        name: Build Collection
-        runs-on: ubuntu-latest
-        needs: [ansible-lint, yaml-lint, python-lint, sanity-test]
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-              with:
-                  python-version: "3.11"
-
-            - name: Install Ansible
-              run: pip install ansible-core
-
-            - name: Build collection
-              run: ansible-galaxy collection build
-
-            - name: Upload collection artifact
-              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-              with:
-                  name: collection
-                  path: "*.tar.gz"
-                  retention-days: 7
+    claude-review:
+        uses: arillso/.github/.github/workflows/ai-claude-review.yml@2026-03-08
+        if: github.event_name == 'pull_request'
+        secrets:
+            CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,25 @@
+---
+name: Claude
+
+on:
+    issue_comment:
+        types: [created]
+    pull_request_review_comment:
+        types: [created]
+    pull_request_review:
+        types: [submitted]
+    issues:
+        types: [opened]
+
+permissions:
+    contents: read
+    pull-requests: read
+    issues: read
+    id-token: write
+    actions: read
+
+jobs:
+    claude:
+        uses: arillso/.github/.github/workflows/ai-claude.yml@2026-03-08
+        secrets:
+            CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,50 +11,9 @@ permissions:
 
 jobs:
     publish:
-        name: Publish to Ansible Galaxy
-        runs-on: ubuntu-latest
-
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-            - name: Get version from tag
-              id: get_version
-              run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-
-            - name: Extract changelog for version
-              id: changelog
-              run: |
-                  VERSION="${{ steps.get_version.outputs.VERSION }}"
-                  # Extract the section for this version from CHANGELOG.md
-                  if [ -f "CHANGELOG.md" ]; then
-                    # Get content between this version and the next version heading
-                    CONTENT=$(sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '$d')
-                    # If the version section is empty, try without brackets
-                    if [ -z "$CONTENT" ]; then
-                      CONTENT=$(sed -n "/## $VERSION/,/## /p" CHANGELOG.md | sed '$d')
-                    fi
-                    # Save to file for multiline support
-                    echo "$CONTENT" > /tmp/changelog.txt
-                    echo "found=true" >> $GITHUB_OUTPUT
-                  else
-                    echo "found=false" >> $GITHUB_OUTPUT
-                  fi
-
-            - name: Set up Python
-              uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-              with:
-                  python-version: "3.11"
-
-            - name: Build and Publish Collection
-              uses: artis3n/ansible_galaxy_collection@415a92b829b5898b6e8ca1dd7a69fe2a1e5fd4c0 # v2
-              with:
-                  api_key: ${{ secrets.GALAXY_API_KEY }}
-
-            - name: Create GitHub Release
-              uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
-              with:
-                  body_path: ${{ steps.changelog.outputs.found == 'true' && '/tmp/changelog.txt' || '' }}
-                  generate_release_notes: ${{ steps.changelog.outputs.found != 'true' }}
-                  draft: false
-                  prerelease: false
+        uses: arillso/.github/.github/workflows/release-ansible-collection.yml@2026-03-08
+        with:
+            collection_namespace: arillso
+            collection_name: system
+        secrets:
+            galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ collections:
 
 ## Documentation
 
-Full documentation is available at:
-<https://guide.arillso.io/collections/arillso/system/>
+Full documentation is available at: [guide.arillso.io][docs]
+
+[docs]: https://guide.arillso.io/collections/arillso/system/?utm_source=github&utm_medium=readme&utm_campaign=documentation
 
 **Breaking Changes in 1.0.0:**
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -27,7 +27,7 @@ dependencies:
 
 repository: https://github.com/arillso/ansible.system
 
-documentation: https://guide.arillso.io/collections/arillso/system/index.html
+documentation: https://guide.arillso.io/collections/arillso/system/index.html?utm_source=ansible_galaxy&utm_medium=metadata&utm_campaign=documentation
 
 homepage: https://arillso.io
 


### PR DESCRIPTION
## Summary

- Replace inline CI jobs (ansible-lint, yaml-lint, python-lint, security-scan, sanity-test, build) with reusable workflows from `arillso/.github`
- Replace inline publish workflow with reusable `release-ansible-collection.yml` workflow
- Add new `claude.yml` workflow for Claude AI integration on issues and PR comments
- Add Claude code review job to CI pipeline for pull requests
- Add `security-secrets` scanning job
- Update documentation links in README.md and galaxy.yml with UTM tracking parameters

## Test plan

- [ ] Verify CI workflow triggers correctly on push/PR to main
- [ ] Verify reusable workflows from `arillso/.github` are accessible
- [ ] Verify publish workflow triggers on tag push
- [ ] Verify Claude workflow triggers on issue/PR comments