### PR TITLE
chore: prepare release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove standalone linter config files (`.flake8`, `.isort.cfg`, `.mypy.ini`,
   `.pylintrc`, `.ruff.toml`, `pyrightconfig.json`, `.yamllint.yml`, `.markdownlint.jsonc`)
 - Remove `tomli` runtime dependency (use stdlib `tomllib` with Python 3.12+)
+- Remove inaccurate `windows` tag from `galaxy.yml`
 
 ### Fixed
 
@@ -39,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `__metaclass__` assignments, and `object` base class)
 - Fix YAML indentation in filter plugin documentation files (2-space to 4-space)
 - Fix markdown lint errors in README, AGENTS.md, and template files
+- Add `no_log` to user management task when password is defined
+- Fix `apt_update_info` module using text progress that pollutes Ansible JSON output
 
 ## [1.0.5] - 2026-01-16
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,7 +18,6 @@ tags:
     - apt
     - systemd
     - linux
-    - windows
 
 dependencies:
     ansible.posix: ">=2.0.0"

--- a/plugins/modules/apt_update_info.py
+++ b/plugins/modules/apt_update_info.py
@@ -57,7 +57,7 @@ from ansible.module_utils.basic import AnsibleModule  # noqa: E402
 
 try:
     import apt  # noqa: E402
-    import apt.progress.text  # noqa: E402
+    import apt.progress.base  # noqa: E402
 
     HAS_APT = True
 except ImportError:
@@ -76,7 +76,7 @@ def main():
 
     try:
         cache = apt.Cache()
-        cache.update(fetch_progress=apt.progress.text.AcquireProgress())
+        cache.update(fetch_progress=apt.progress.base.AcquireProgress())
         cache.open(None)
 
         for pkg in cache:

--- a/roles/access/tasks/users.yml
+++ b/roles/access/tasks/users.yml
@@ -15,6 +15,7 @@
       password: "{{ _access_user_item.password | default(omit) }}"
       update_password: "{{ _access_user_item.update_password | default(access_user_update_password_default) }}"
       remove: "{{ _access_user_item.remove | default(false) }}"
+  no_log: "{{ _access_user_item.password is defined }}"
   become: true
   loop: "{{ access_users }}"
   loop_control:


### PR DESCRIPTION
## Summary

- Update `galaxy.yml` version to 1.1.0
- Update `CHANGELOG.md` with all changes since 1.0.5

## Changes since 1.0.5

### Added
- Claude AI code review and automation workflows
- CONTRIBUTING.md

### Changed
- CI/publish migrated to reusable org-level workflows
- Python minimum 3.11 → 3.12
- Dependencies updated (ansible-lint v26, black v26, molecule v26, pytest-cov v7, sphinx v9.1)
- Linter configs consolidated into pyproject.toml

### Removed
- Standalone linter config files (.flake8, .isort.cfg, .mypy.ini, .pylintrc, etc.)
- `tomli` dependency (stdlib `tomllib` with Python 3.12+)

### Fixed
- Python plugin lint cleanup
- YAML indentation fixes
- Markdown lint fixes

## Release steps after merge
1. Merge this PR
2. `git tag 1.1.0 && git push origin 1.1.0`
3. Publish workflow triggers automatically