### PR TITLE
Release 1.1.2: fix tuning handler notify case + dependency bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-05-02
+
+### Changed
+
+- Update `arillso/.github` reusable workflows and Renovate preset to v2026-03-25
+- Update Python dev dependencies: ansible-lint v26.4.0, ruff v0.15.12, black v26.3.1,
+  molecule v26.4.0, pytest v9.0.3, pytest-ansible v26.4.0, pytest-cov v7.1.0
+
+### Fixed
+
+- Align handler notify names in tuning role with handler definitions; the lowercase
+  notify entries (`reload systemd`, `enable network tuning service`,
+  `enable disable-thp service`) silently never matched the capitalized handlers,
+  so the systemd daemon-reload and the network-tuning/disable-thp service activations
+  never ran when their templates changed
+
 ## [1.1.1] - 2026-03-18
 
 ### Added
@@ -210,7 +226,8 @@ Users need to migrate to the new role structure. See role documentation for migr
 
 For releases prior to this changelog format change, see: <https://github.com/arillso/ansible.system/releases>
 
-[Unreleased]: https://github.com/arillso/ansible.system/compare/1.1.1...HEAD
+[Unreleased]: https://github.com/arillso/ansible.system/compare/1.1.2...HEAD
+[1.1.2]: https://github.com/arillso/ansible.system/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/arillso/ansible.system/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/arillso/ansible.system/compare/1.0.5...1.1.0
 [1.0.5]: https://github.com/arillso/ansible.system/compare/1.0.4...1.0.5

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: system
-version: 1.1.1
+version: 1.1.2
 readme: README.md
 
 authors:

--- a/roles/tuning/tasks/main.yml
+++ b/roles/tuning/tasks/main.yml
@@ -125,8 +125,8 @@
             group: root
         become: true
         notify:
-            - reload systemd
-            - enable disable-thp service
+            - Reload systemd
+            - Enable disable-thp service
         when:
             - tuning_transparent_hugepages is defined
             - thp_result is not failed

--- a/roles/tuning/tasks/network.yml
+++ b/roles/tuning/tasks/network.yml
@@ -76,8 +76,8 @@
             group: root
         become: true
         notify:
-            - reload systemd
-            - enable network tuning service
+            - Reload systemd
+            - Enable network tuning service
         when: valid_network_buffers is defined and valid_network_buffers | length > 0
 
 - name: Configure network interface specific settings


### PR DESCRIPTION
## Summary

- **fix(tuning):** Align handler `notify` names in `roles/tuning/tasks/main.yml` and `roles/tuning/tasks/network.yml` with the capitalized handler definitions in `roles/tuning/handlers/main.yml`. Ansible handler names are case-sensitive, so the lowercase `reload systemd`, `enable network tuning service`, and `enable disable-thp service` notifies silently never matched, leaving the systemd `daemon-reload` and the `network-tuning`/`disable-thp` service activations un-run when their templates changed.
- **chore(deps):** Pick up the Renovate bumps that landed on main since 1.1.1 — `arillso/.github` reusable workflows + Renovate preset to `v2026-03-25`, plus Python dev deps (ansible-lint 26.4.0, ruff 0.15.12, black 26.3.1, molecule 26.4.0, pytest 9.0.3, pytest-ansible 26.4.0, pytest-cov 7.1.0).
- **release prep:** CHANGELOG entry for `[1.1.2] - 2026-05-02` and `galaxy.yml` version bumped to `1.1.2`.

## Test plan

- [ ] MegaLinter / reusable CI workflow passes on the PR
- [ ] After merge: tag `1.1.2` (no `v` prefix) on `main` to trigger the publish workflow → Ansible Galaxy + GitHub Release