### PR TITLE
Release 1.1.3: fix systemd unit destination directory not created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3] - 2026-05-02
+
+### Fixed
+
+- Ensure the destination directory exists before deploying systemd unit files in the
+  `systemd` role; previously `unit.yml` only worked when `systemd_unit_path` was the
+  default `/etc/systemd/system`. Callers passing a drop-in directory such as
+  `/etc/systemd/system/<unit>.d` (e.g. the `firewall` role for `nftables.service.d`)
+  failed on hosts where the directory did not yet exist
+
 ## [1.1.2] - 2026-05-02
 
 ### Changed
@@ -226,7 +236,8 @@ Users need to migrate to the new role structure. See role documentation for migr
 
 For releases prior to this changelog format change, see: <https://github.com/arillso/ansible.system/releases>
 
-[Unreleased]: https://github.com/arillso/ansible.system/compare/1.1.2...HEAD
+[Unreleased]: https://github.com/arillso/ansible.system/compare/1.1.3...HEAD
+[1.1.3]: https://github.com/arillso/ansible.system/compare/1.1.2...1.1.3
 [1.1.2]: https://github.com/arillso/ansible.system/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/arillso/ansible.system/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/arillso/ansible.system/compare/1.0.5...1.1.0

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: system
-version: 1.1.2
+version: 1.1.3
 readme: README.md
 
 authors:

--- a/roles/systemd/defaults/main.yml
+++ b/roles/systemd/defaults/main.yml
@@ -37,6 +37,7 @@ systemd_unit_path: /etc/systemd/system
 systemd_unit_owner: root
 systemd_unit_group: root
 systemd_unit_mode: "0644"
+systemd_unit_dir_mode: "0755"
 
 # Journald Configuration
 systemd_journald_storage: auto

--- a/roles/systemd/meta/argument_specs.yml
+++ b/roles/systemd/meta/argument_specs.yml
@@ -85,6 +85,10 @@ argument_specs:
                 description: "File mode for systemd unit files"
                 type: str
                 default: "0644"
+            systemd_unit_dir_mode:
+                description: "Directory mode for the systemd unit destination path"
+                type: str
+                default: "0755"
 
             # Journald Configuration
             systemd_journald_storage:
@@ -315,6 +319,10 @@ argument_specs:
                 description: "File mode for systemd unit files"
                 type: str
                 default: "0644"
+            systemd_unit_dir_mode:
+                description: "Directory mode for the systemd unit destination path"
+                type: str
+                default: "0755"
             systemd_validate_units:
                 description: "Validate unit files before deploying"
                 type: bool

--- a/roles/systemd/tasks/unit.yml
+++ b/roles/systemd/tasks/unit.yml
@@ -5,7 +5,7 @@
       state: directory
       owner: "{{ systemd_unit_owner }}"
       group: "{{ systemd_unit_group }}"
-      mode: "0755"
+      mode: "{{ systemd_unit_dir_mode }}"
   become: true
   when: systemd_units | length > 0
 

--- a/roles/systemd/tasks/unit.yml
+++ b/roles/systemd/tasks/unit.yml
@@ -1,4 +1,14 @@
 ---
+- name: Ensure systemd unit destination directory exists
+  ansible.builtin.file:
+      path: "{{ systemd_unit_path }}"
+      state: directory
+      owner: "{{ systemd_unit_owner }}"
+      group: "{{ systemd_unit_group }}"
+      mode: "0755"
+  become: true
+  when: systemd_units | length > 0
+
 - name: Deploy systemd unit files (raw content)
   ansible.builtin.copy:
       content: "{{ _systemd_unit_item.content }}"


### PR DESCRIPTION
## Summary

- `roles/systemd/tasks/unit.yml` deployte Unit-Dateien direkt nach `{{ systemd_unit_path }}/{{ name }}`, ohne das Zielverzeichnis vorher anzulegen. Funktionierte nur mit dem Default `/etc/systemd/system`.
- Caller, die einen Drop-in-Pfad übergeben — z. B. `roles/firewall/tasks/main.yml` mit `systemd_unit_path: /etc/systemd/system/nftables.service.d` für eine `override.conf` — failten auf sauberen Hosts mit `Destination directory does not exist`.
- Fix: ein idempotenter `ansible.builtin.file: state=directory` Schritt vor den Deploy-Tasks. Der Role übernimmt damit die Verantwortung für seinen eigenen Output-Pfad.
- CHANGELOG- und `galaxy.yml`-Bump auf 1.1.3.

## Test plan

- [ ] CI grün (MegaLinter)
- [ ] Manuell: `firewall` Role auf einem Host ohne `/etc/systemd/system/nftables.service.d/` durchlaufen lassen — `override.conf` wird angelegt, Verzeichnis vorher erzeugt
- [ ] Default-Pfad `/etc/systemd/system` weiterhin idempotent (kein Mode-/Owner-Drift)