### PR TITLE
Release 1.1.4: fix packages keys controller-side check + YAML-folded cmd split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.4] - 2026-05-02
+
+### Fixed
+
+- `packages` role now stats the target keyring on the host before deciding
+  whether to (re-)download armored key material to `/tmp`. The previous
+  `is file` Jinja test ran on the controller, so a controller that already
+  had the keyring cached would skip the download even when the target was
+  fresh, leaving the host without a keyring and the dearmor task without
+  its source file
+- `packages` role dearmor and keyserver shell tasks no longer use a folded
+  scalar (`>-`) with multi-line Jinja path expressions in `cmd:`. The
+  more-indented Jinja continuation lines preserved their newlines through
+  YAML folding, which split the rendered command into two shell statements
+  — `gpg --dearmor -o <path>` (with no stdin redirect, producing an empty
+  keyring at exit 0 because of `-o`) and an orphan `< "$_tmp"` redirect.
+  The result was a 0-byte keyring file that apt rejected with `NO_PUBKEY`,
+  silently breaking package installs (e.g. `alloy` from the Grafana repo).
+  Paths are now precomputed via task-level `vars:` and the command body is
+  written as a literal block (`|`) with one shell statement per line
+
 ## [1.1.3] - 2026-05-02
 
 ### Fixed
@@ -236,7 +257,8 @@ Users need to migrate to the new role structure. See role documentation for migr
 
 For releases prior to this changelog format change, see: <https://github.com/arillso/ansible.system/releases>
 
-[Unreleased]: https://github.com/arillso/ansible.system/compare/1.1.3...HEAD
+[Unreleased]: https://github.com/arillso/ansible.system/compare/1.1.4...HEAD
+[1.1.4]: https://github.com/arillso/ansible.system/compare/1.1.3...1.1.4
 [1.1.3]: https://github.com/arillso/ansible.system/compare/1.1.2...1.1.3
 [1.1.2]: https://github.com/arillso/ansible.system/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/arillso/ansible.system/compare/1.1.0...1.1.1

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: system
-version: 1.1.3
+version: 1.1.4
 readme: README.md
 
 authors:

--- a/roles/packages/tasks/keys.yml
+++ b/roles/packages/tasks/keys.yml
@@ -54,6 +54,26 @@
   register: _packages_keys_added_url_keyring
   become: true
 
+- name: Stat target keyrings on the host (URL with keyring)
+  ansible.builtin.stat:
+      path: >-
+          {{ _pkg_key_item.keyring |
+             default('/usr/share/keyrings/' + (_pkg_key_item.name | default('custom')) +
+                     '-keyring.gpg') }}
+  loop: "{{ packages_keys }}"
+  loop_control:
+      loop_var: _pkg_key_item
+      label: "{{ _pkg_key_item.name | default(_pkg_key_item.id | default('custom')) }}"
+  when:
+      - packages_keys | length > 0
+      - _pkg_key_item.url is defined
+      - _pkg_key_item.keyring is defined
+      - _pkg_key_item.state | default('present') == 'present'
+      - _pkg_key_item.dearmor | default(false)
+  register: _packages_keys_target_stat_url_keyring
+  changed_when: false
+  become: true
+
 - name: Download APT signing keys for dearmoring (URL with keyring)
   ansible.builtin.get_url:
       url: "{{ _pkg_key_item.url }}"
@@ -63,37 +83,37 @@
   loop: "{{ packages_keys }}"
   loop_control:
       loop_var: _pkg_key_item
+      extended: true
+      label: "{{ _pkg_key_item.name | default('custom') }}"
   when:
       - packages_keys | length > 0
       - _pkg_key_item.url is defined
       - _pkg_key_item.keyring is defined
       - _pkg_key_item.state | default('present') == 'present'
       - _pkg_key_item.dearmor | default(false)
-      - not (_pkg_key_item.keyring |
-        default('/usr/share/keyrings/' + (_pkg_key_item.name | default('custom')) +
-        '-keyring.gpg')) is file or packages_keys_force_update
+      - not (_packages_keys_target_stat_url_keyring.results[ansible_loop.index0].stat.exists | default(false))
+        or packages_keys_force_update
   register: _packages_keys_downloaded_url_keyring_dearmor
   become: true
 
 - name: Dearmor APT signing keys (URL with keyring)
-  ansible.builtin.shell:
-      cmd: >-
-          set -o pipefail &&
-          _tmp="/tmp/{{ _pkg_key_item.name | default('custom') }}-armored.asc" &&
-          trap 'rm -f "$_tmp"' EXIT &&
-          gpg --dearmor -o
-          {{ _pkg_key_item.keyring |
-             default('/usr/share/keyrings/' + (_pkg_key_item.name | default('custom')) +
-                     '-keyring.gpg') | quote }}
-          < "$_tmp"
-      executable: /bin/bash
-      creates: >-
+  vars:
+      _pkg_key_keyring_path: >-
           {{ _pkg_key_item.keyring |
              default('/usr/share/keyrings/' + (_pkg_key_item.name | default('custom')) +
                      '-keyring.gpg') }}
+      _pkg_key_armored_path: "/tmp/{{ _pkg_key_item.name | default('custom') }}-armored.asc"
+  ansible.builtin.shell:
+      cmd: |
+          set -e
+          trap "rm -f {{ _pkg_key_armored_path | quote }}" EXIT
+          gpg --dearmor -o {{ _pkg_key_keyring_path | quote }} < {{ _pkg_key_armored_path | quote }}
+      executable: /bin/bash
+      creates: "{{ _pkg_key_keyring_path }}"
   loop: "{{ packages_keys }}"
   loop_control:
       loop_var: _pkg_key_item
+      label: "{{ _pkg_key_item.name | default('custom') }}"
   when:
       - packages_keys | length > 0
       - _pkg_key_item.url is defined
@@ -144,6 +164,23 @@
   register: _packages_keys_added_url
   become: true
 
+- name: Stat target keyrings on the host (URL without keyring)
+  ansible.builtin.stat:
+      path: "/usr/share/keyrings/{{ _pkg_key_item.name | default('custom') }}-keyring.gpg"
+  loop: "{{ packages_keys }}"
+  loop_control:
+      loop_var: _pkg_key_item
+      label: "{{ _pkg_key_item.name | default('custom') }}"
+  when:
+      - packages_keys | length > 0
+      - _pkg_key_item.url is defined
+      - _pkg_key_item.keyring is not defined
+      - _pkg_key_item.state | default('present') == 'present'
+      - _pkg_key_item.dearmor | default(false)
+  register: _packages_keys_target_stat_url
+  changed_when: false
+  become: true
+
 - name: Download APT signing keys for dearmoring (URL without keyring)
   ansible.builtin.get_url:
       url: "{{ _pkg_key_item.url }}"
@@ -153,32 +190,34 @@
   loop: "{{ packages_keys }}"
   loop_control:
       loop_var: _pkg_key_item
+      extended: true
+      label: "{{ _pkg_key_item.name | default('custom') }}"
   when:
       - packages_keys | length > 0
       - _pkg_key_item.url is defined
       - _pkg_key_item.keyring is not defined
       - _pkg_key_item.state | default('present') == 'present'
       - _pkg_key_item.dearmor | default(false)
-      - not ('/usr/share/keyrings/' + (_pkg_key_item.name | default('custom')) +
-        '-keyring.gpg') is file or packages_keys_force_update
+      - not (_packages_keys_target_stat_url.results[ansible_loop.index0].stat.exists | default(false))
+        or packages_keys_force_update
   register: _packages_keys_downloaded_url_dearmor
   become: true
 
 - name: Dearmor APT signing keys (URL without keyring)
+  vars:
+      _pkg_key_keyring_path: "/usr/share/keyrings/{{ _pkg_key_item.name | default('custom') }}-keyring.gpg"
+      _pkg_key_armored_path: "/tmp/{{ _pkg_key_item.name | default('custom') }}-armored.asc"
   ansible.builtin.shell:
-      cmd: >-
-          set -o pipefail &&
-          _tmp="/tmp/{{ _pkg_key_item.name | default('custom') }}-armored.asc" &&
-          trap 'rm -f "$_tmp"' EXIT &&
-          gpg --dearmor -o
-          {{ ('/usr/share/keyrings/' + (_pkg_key_item.name | default('custom')) +
-              '-keyring.gpg') | quote }}
-          < "$_tmp"
+      cmd: |
+          set -e
+          trap "rm -f {{ _pkg_key_armored_path | quote }}" EXIT
+          gpg --dearmor -o {{ _pkg_key_keyring_path | quote }} < {{ _pkg_key_armored_path | quote }}
       executable: /bin/bash
-      creates: "/usr/share/keyrings/{{ _pkg_key_item.name | default('custom') }}-keyring.gpg"
+      creates: "{{ _pkg_key_keyring_path }}"
   loop: "{{ packages_keys }}"
   loop_control:
       loop_var: _pkg_key_item
+      label: "{{ _pkg_key_item.name | default('custom') }}"
   when:
       - packages_keys | length > 0
       - _pkg_key_item.url is defined
@@ -206,27 +245,24 @@
   become: true
 
 - name: Fetch APT signing keys from keyserver
-  ansible.builtin.shell:
-      cmd: >-
-          set -o pipefail &&
-          _tmpfile=$(mktemp --suffix=.gpg) &&
-          trap 'rm -f "$_tmpfile" "${_tmpfile}~"' EXIT &&
-          gpg --no-default-keyring --keyring "$_tmpfile"
-          --keyserver {{ _pkg_key_item.keyserver | quote }}
-          --recv-keys {{ _pkg_key_item.id | quote }} &&
-          gpg --no-default-keyring --keyring "$_tmpfile"
-          --export {{ _pkg_key_item.id | quote }} >
-          {{ (_pkg_key_item.keyring |
-              default('/usr/share/keyrings/' + (_pkg_key_item.name | default(_pkg_key_item.id)) +
-                      '-keyring.gpg')) | quote }}
-      executable: /bin/bash
-      creates: >-
+  vars:
+      _pkg_key_keyring_path: >-
           {{ _pkg_key_item.keyring |
              default('/usr/share/keyrings/' + (_pkg_key_item.name | default(_pkg_key_item.id)) +
                      '-keyring.gpg') }}
+  ansible.builtin.shell:
+      cmd: |
+          set -e
+          _tmpfile=$(mktemp --suffix=.gpg)
+          trap 'rm -f "$_tmpfile" "${_tmpfile}~"' EXIT
+          gpg --no-default-keyring --keyring "$_tmpfile" --keyserver {{ _pkg_key_item.keyserver | quote }} --recv-keys {{ _pkg_key_item.id | quote }}
+          gpg --no-default-keyring --keyring "$_tmpfile" --export {{ _pkg_key_item.id | quote }} > {{ _pkg_key_keyring_path | quote }}
+      executable: /bin/bash
+      creates: "{{ _pkg_key_keyring_path }}"
   loop: "{{ packages_keys }}"
   loop_control:
       loop_var: _pkg_key_item
+      label: "{{ _pkg_key_item.name | default(_pkg_key_item.id) }}"
   when:
       - packages_keys | length > 0
       - _pkg_key_item.keyserver is defined
@@ -254,6 +290,24 @@
       - _pkg_key_item.state | default('present') == 'present'
   become: true
 
+- name: Stat target keyrings on the host (data)
+  ansible.builtin.stat:
+      path: >-
+          {{ _pkg_key_item.keyring |
+             default('/usr/share/keyrings/' + (_pkg_key_item.name | default('custom-data')) +
+                     '-keyring.gpg') }}
+  loop: "{{ packages_keys }}"
+  loop_control:
+      loop_var: _pkg_key_item
+      label: "{{ _pkg_key_item.name | default('custom-data') }}"
+  when:
+      - packages_keys | length > 0
+      - _pkg_key_item.data is defined
+      - _pkg_key_item.state | default('present') == 'present'
+  register: _packages_keys_target_stat_data
+  changed_when: false
+  become: true
+
 - name: Write APT signing key data to temp file
   ansible.builtin.copy:
       content: "{{ _pkg_key_item.data }}"
@@ -262,35 +316,35 @@
   loop: "{{ packages_keys }}"
   loop_control:
       loop_var: _pkg_key_item
+      extended: true
+      label: "{{ _pkg_key_item.name | default('custom-data') }}"
   when:
       - packages_keys | length > 0
       - _pkg_key_item.data is defined
       - _pkg_key_item.state | default('present') == 'present'
-      - not (_pkg_key_item.keyring |
-        default('/usr/share/keyrings/' + (_pkg_key_item.name | default('custom-data')) +
-        '-keyring.gpg')) is file or packages_keys_force_update
+      - not (_packages_keys_target_stat_data.results[ansible_loop.index0].stat.exists | default(false))
+        or packages_keys_force_update
   register: _packages_keys_data_written
   become: true
 
 - name: Dearmor APT signing keys from data
-  ansible.builtin.shell:
-      cmd: >-
-          set -o pipefail &&
-          _tmp="/tmp/{{ _pkg_key_item.name | default('custom-data') }}-armored.asc" &&
-          trap 'rm -f "$_tmp"' EXIT &&
-          gpg --dearmor -o
-          {{ (_pkg_key_item.keyring |
-              default('/usr/share/keyrings/' + (_pkg_key_item.name | default('custom-data')) +
-                      '-keyring.gpg')) | quote }}
-          < "$_tmp"
-      executable: /bin/bash
-      creates: >-
+  vars:
+      _pkg_key_keyring_path: >-
           {{ _pkg_key_item.keyring |
              default('/usr/share/keyrings/' + (_pkg_key_item.name | default('custom-data')) +
                      '-keyring.gpg') }}
+      _pkg_key_armored_path: "/tmp/{{ _pkg_key_item.name | default('custom-data') }}-armored.asc"
+  ansible.builtin.shell:
+      cmd: |
+          set -e
+          trap "rm -f {{ _pkg_key_armored_path | quote }}" EXIT
+          gpg --dearmor -o {{ _pkg_key_keyring_path | quote }} < {{ _pkg_key_armored_path | quote }}
+      executable: /bin/bash
+      creates: "{{ _pkg_key_keyring_path }}"
   loop: "{{ packages_keys }}"
   loop_control:
       loop_var: _pkg_key_item
+      label: "{{ _pkg_key_item.name | default('custom-data') }}"
   when:
       - packages_keys | length > 0
       - _pkg_key_item.data is defined

--- a/roles/packages/tasks/keys.yml
+++ b/roles/packages/tasks/keys.yml
@@ -72,7 +72,6 @@
       - _pkg_key_item.dearmor | default(false)
   register: _packages_keys_target_stat_url_keyring
   changed_when: false
-  become: true
 
 - name: Download APT signing keys for dearmoring (URL with keyring)
   ansible.builtin.get_url:
@@ -106,8 +105,9 @@
   ansible.builtin.shell:
       cmd: |
           set -e
-          trap "rm -f {{ _pkg_key_armored_path | quote }}" EXIT
-          gpg --dearmor -o {{ _pkg_key_keyring_path | quote }} < {{ _pkg_key_armored_path | quote }}
+          _tmp={{ _pkg_key_armored_path | quote }}
+          trap 'rm -f "$_tmp"' EXIT
+          gpg --dearmor -o {{ _pkg_key_keyring_path | quote }} < "$_tmp"
       executable: /bin/bash
       creates: "{{ _pkg_key_keyring_path }}"
   loop: "{{ packages_keys }}"
@@ -179,7 +179,6 @@
       - _pkg_key_item.dearmor | default(false)
   register: _packages_keys_target_stat_url
   changed_when: false
-  become: true
 
 - name: Download APT signing keys for dearmoring (URL without keyring)
   ansible.builtin.get_url:
@@ -210,8 +209,9 @@
   ansible.builtin.shell:
       cmd: |
           set -e
-          trap "rm -f {{ _pkg_key_armored_path | quote }}" EXIT
-          gpg --dearmor -o {{ _pkg_key_keyring_path | quote }} < {{ _pkg_key_armored_path | quote }}
+          _tmp={{ _pkg_key_armored_path | quote }}
+          trap 'rm -f "$_tmp"' EXIT
+          gpg --dearmor -o {{ _pkg_key_keyring_path | quote }} < "$_tmp"
       executable: /bin/bash
       creates: "{{ _pkg_key_keyring_path }}"
   loop: "{{ packages_keys }}"
@@ -306,7 +306,6 @@
       - _pkg_key_item.state | default('present') == 'present'
   register: _packages_keys_target_stat_data
   changed_when: false
-  become: true
 
 - name: Write APT signing key data to temp file
   ansible.builtin.copy:
@@ -337,8 +336,9 @@
   ansible.builtin.shell:
       cmd: |
           set -e
-          trap "rm -f {{ _pkg_key_armored_path | quote }}" EXIT
-          gpg --dearmor -o {{ _pkg_key_keyring_path | quote }} < {{ _pkg_key_armored_path | quote }}
+          _tmp={{ _pkg_key_armored_path | quote }}
+          trap 'rm -f "$_tmp"' EXIT
+          gpg --dearmor -o {{ _pkg_key_keyring_path | quote }} < "$_tmp"
       executable: /bin/bash
       creates: "{{ _pkg_key_keyring_path }}"
   loop: "{{ packages_keys }}"


### PR DESCRIPTION
## Summary

Two upstream bugs in `roles/packages/tasks/keys.yml` made deb-repo keys silently broken on fresh hosts.

### Bug A — controller-side `is file` check

The "skip the dearmor /tmp download if the keyring already exists" guard at L72-74, L162-163, L269-271 used the Jinja `is file` test on the destination keyring path. Jinja runs on the controller, not the target — so the test inspected `/usr/share/keyrings` on the machine running ansible, not on the host that needed the key. When controller and target diverged (controller had a stale cached keyring from a previous run, target was fresh), the /tmp armored download was skipped and the dearmor step ran without input.

**Fix:** replace each `is file` precondition with an `ansible.builtin.stat` task that runs on the target and feed the result into the download `when:` via `loop_control.extended` + `ansible_loop.index0`.

### Bug B — YAML-folded `cmd:` split into two shell statements

The dearmor and keyserver shell tasks at L78-93, L167-176, L208-236, L275-285 built `cmd:` as a folded scalar (`>-`) containing multi-line Jinja path expressions. The continuation lines inside `default(...)` were more indented than the folded-block base, so YAML preserved their leading newlines as literal `\n` instead of folding them to spaces.

After rendering, `cmd:` ended as:

```
gpg --dearmor -o '/usr/share/keyrings/<name>-keyring.gpg'
 < "$_tmp"
```

bash ran two statements:

1. `gpg --dearmor -o <path>` — no stdin redirect → `gpg: no valid OpenPGP data found`, but `-o` already created an empty file, exit 0
2. `< "$_tmp"` — bare redirect, no-op, exit 0

Result: a 0-byte keyring file. apt rejected the empty signature with `NO_PUBKEY <id>` and refused the repo, breaking installs from affected repos (e.g. `alloy` from the Grafana repo).

**Fix:** precompute keyring/armored paths via task-level `vars:` and write `cmd:` as a literal block (`|`) with one self-contained shell statement per line. Newlines can no longer leak inside a single shell command. Same treatment for the keyserver task — currently harmless by accident because the path is at the very end of the folded scalar, but structurally fragile.

## Test plan

- [ ] CI grün (MegaLinter, ansible-lint, yamllint)
- [ ] Manuell: Grafana-Repo (`alloy`) auf einem fresh Debian-Host installieren — Keyring darf nicht 0 Byte sein, `apt-get update` darf kein NO_PUBKEY werfen, `apt-get install alloy` muss durchgehen
- [ ] Mit `packages_keys_force_update: true` → `Remove existing keyrings`-Task entfernt, stat findet nichts, Download + Dearmor laufen → Keyring liegt am Ende mit korrekter Grösse
- [ ] Idempotenz: zweiter Lauf ohne Force → stat findet Keyring, Download wird skipped, Dearmor wird via `creates:` skipped