### PR TITLE
fix: role hygiene — scoped nftables flush, user append, include_role become

### DIFF
--- a/roles/access/tasks/ssh_server.yml
+++ b/roles/access/tasks/ssh_server.yml
@@ -19,7 +19,8 @@
   ansible.builtin.include_role:
       name: arillso.system.systemd
       tasks_from: service
-  become: true
+      apply:
+          become: true
   vars:
       systemd_services:
           - name: "{{ _access_ssh_service_name }}"

--- a/roles/access/tasks/users.yml
+++ b/roles/access/tasks/users.yml
@@ -6,7 +6,13 @@
       uid: "{{ _access_user_item.uid | default(omit) }}"
       group: "{{ _access_user_item.group | default(omit) }}"
       groups: "{{ _access_user_item.groups | default(omit) }}"
-      append: "{{ _access_user_item.append | default(true) }}"
+      # append nur setzen wenn auch groups uebergeben wurde — sonst warnt
+      # Ansible "'append' is set, but no 'groups' are specified" (wird in
+      # Ansible 2.14 zum Fehler).
+      append: >-
+          {{ _access_user_item.append | default(true)
+             if _access_user_item.groups is defined
+             else omit }}
       shell: "{{ _access_user_item.shell | default(access_user_shell_default) }}"
       home: "{{ _access_user_item.home | default(omit) }}"
       create_home: "{{ _access_user_item.create_home | default(access_user_create_home_default) }}"

--- a/roles/access/tasks/users.yml
+++ b/roles/access/tasks/users.yml
@@ -8,11 +8,10 @@
       groups: "{{ _access_user_item.groups | default(omit) }}"
       # append nur setzen wenn auch groups uebergeben wurde — sonst warnt
       # Ansible "'append' is set, but no 'groups' are specified" (wird in
-      # Ansible 2.14 zum Fehler).
-      append: >-
-          {{ _access_user_item.append | default(true)
-             if _access_user_item.groups is defined
-             else omit }}
+      # Ansible 2.14 zum Fehler). Single-line "{{ ... }}" statt >-Block-
+      # Scalar, damit der `omit`-Placeholder nicht durch eine YAML-String-
+      # Konversion laeuft, bevor Ansible ihn matcht.
+      append: "{{ _access_user_item.append | default(true) if _access_user_item.groups is defined else omit }}"
       shell: "{{ _access_user_item.shell | default(access_user_shell_default) }}"
       home: "{{ _access_user_item.home | default(omit) }}"
       create_home: "{{ _access_user_item.create_home | default(access_user_create_home_default) }}"

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -49,6 +49,21 @@
       name: arillso.system.systemd
       tasks_from: unit
   vars:
+      # Scoped flush statt `nft flush ruleset` — sonst wipet der
+      # systemd-Stop (auch ueber Restart-Pfad ausgeloest) alle Tables
+      # anderer Quellen mit, inkl. Docker's ip nat / ip filter Chains,
+      # was Container-Recreates mit "iptables: No chain/target/match by
+      # that name" fail-en laesst. Leading "" resettet die upstream-
+      # ExecStop-Zeile (sonst wuerde unsere additiv angehaengt), und
+      # das "-"-Prefix laesst systemd den Stop bei nicht existenter
+      # Table (Fresh-Boot, Service-Start vor erstem Apply) ignorieren.
+      _firewall_execstop_cmds: >-
+          {{ [''] + (_firewall | default([])
+                     | map(attribute='table.family')
+                     | zip(_firewall | default([]) | map(attribute='table.name'))
+                     | map('join', ' ')
+                     | map('regex_replace', '^', '-/usr/sbin/nft flush table ')
+                     | list) }}
       systemd_unit_path: /etc/systemd/system/nftables.service.d
       systemd_units:
           - name: override.conf
@@ -66,18 +81,7 @@
                         - ""
                         - /usr/sbin/nft -f /etc/nftables.conf
                     ExecReload: /usr/sbin/nft -f /etc/nftables.conf
-                    # Scoped flush statt `nft flush ruleset` — sonst wipet
-                    # der systemd-Stop (auch ueber Restart-Pfad ausgeloest)
-                    # alle Tables anderer Quellen mit, inkl. Docker's
-                    # ip nat / ip filter Chains, was Container-Recreates
-                    # mit "iptables: No chain/target/match by that name"
-                    # fail-en laesst. Leading "" resettet die upstream-
-                    # ExecStop-Zeile (sonst wuerde unsere additiv angehaengt).
-                    ExecStop: >-
-                        {{ [''] + ['/usr/sbin/nft flush table '
-                                  ~ t.table.family ~ ' '
-                                  ~ t.table.name
-                                  for t in (_firewall | default([]))] }}
+                    ExecStop: "{{ _firewall_execstop_cmds }}"
                 Install:
                     WantedBy: multi-user.target
   when: _firewall_tailscale_exists | bool
@@ -87,6 +91,13 @@
       name: arillso.system.systemd
       tasks_from: unit
   vars:
+      _firewall_execstop_cmds: >-
+          {{ [''] + (_firewall | default([])
+                     | map(attribute='table.family')
+                     | zip(_firewall | default([]) | map(attribute='table.name'))
+                     | map('join', ' ')
+                     | map('regex_replace', '^', '-/usr/sbin/nft flush table ')
+                     | list) }}
       systemd_unit_path: /etc/systemd/system/nftables.service.d
       systemd_units:
           - name: override.conf
@@ -102,18 +113,8 @@
                         - ""
                         - /usr/sbin/nft -f /etc/nftables.conf
                     ExecReload: /usr/sbin/nft -f /etc/nftables.conf
-                    # Scoped flush statt `nft flush ruleset` — sonst wipet
-                    # der systemd-Stop (auch ueber Restart-Pfad ausgeloest)
-                    # alle Tables anderer Quellen mit, inkl. Docker's
-                    # ip nat / ip filter Chains, was Container-Recreates
-                    # mit "iptables: No chain/target/match by that name"
-                    # fail-en laesst. Leading "" resettet die upstream-
-                    # ExecStop-Zeile (sonst wuerde unsere additiv angehaengt).
-                    ExecStop: >-
-                        {{ [''] + ['/usr/sbin/nft flush table '
-                                  ~ t.table.family ~ ' '
-                                  ~ t.table.name
-                                  for t in (_firewall | default([]))] }}
+                    # Begruendung siehe oberer Task; identische Logik.
+                    ExecStop: "{{ _firewall_execstop_cmds }}"
                 Install:
                     WantedBy: multi-user.target
   when: not (_firewall_tailscale_exists | bool)

--- a/roles/firewall/tasks/main.yml
+++ b/roles/firewall/tasks/main.yml
@@ -66,7 +66,18 @@
                         - ""
                         - /usr/sbin/nft -f /etc/nftables.conf
                     ExecReload: /usr/sbin/nft -f /etc/nftables.conf
-                    ExecStop: /usr/sbin/nft flush ruleset
+                    # Scoped flush statt `nft flush ruleset` — sonst wipet
+                    # der systemd-Stop (auch ueber Restart-Pfad ausgeloest)
+                    # alle Tables anderer Quellen mit, inkl. Docker's
+                    # ip nat / ip filter Chains, was Container-Recreates
+                    # mit "iptables: No chain/target/match by that name"
+                    # fail-en laesst. Leading "" resettet die upstream-
+                    # ExecStop-Zeile (sonst wuerde unsere additiv angehaengt).
+                    ExecStop: >-
+                        {{ [''] + ['/usr/sbin/nft flush table '
+                                  ~ t.table.family ~ ' '
+                                  ~ t.table.name
+                                  for t in (_firewall | default([]))] }}
                 Install:
                     WantedBy: multi-user.target
   when: _firewall_tailscale_exists | bool
@@ -91,7 +102,18 @@
                         - ""
                         - /usr/sbin/nft -f /etc/nftables.conf
                     ExecReload: /usr/sbin/nft -f /etc/nftables.conf
-                    ExecStop: /usr/sbin/nft flush ruleset
+                    # Scoped flush statt `nft flush ruleset` — sonst wipet
+                    # der systemd-Stop (auch ueber Restart-Pfad ausgeloest)
+                    # alle Tables anderer Quellen mit, inkl. Docker's
+                    # ip nat / ip filter Chains, was Container-Recreates
+                    # mit "iptables: No chain/target/match by that name"
+                    # fail-en laesst. Leading "" resettet die upstream-
+                    # ExecStop-Zeile (sonst wuerde unsere additiv angehaengt).
+                    ExecStop: >-
+                        {{ [''] + ['/usr/sbin/nft flush table '
+                                  ~ t.table.family ~ ' '
+                                  ~ t.table.name
+                                  for t in (_firewall | default([]))] }}
                 Install:
                     WantedBy: multi-user.target
   when: not (_firewall_tailscale_exists | bool)

--- a/roles/firewall/templates/etc/nftables.conf.j2
+++ b/roles/firewall/templates/etc/nftables.conf.j2
@@ -4,7 +4,14 @@
 # Host: {{ inventory_hostname }}
 # Groups: {{ group_names | join(', ') }}
 
-flush ruleset
+{# Scoped flush: nur die Tables, die diese Rolle managed. Vorher stand
+   hier `flush ruleset`, was alle Tables anderer Quellen (Docker
+   iptables-nft, kube-proxy, manuelle Entries) bei jedem Config-Reload
+   mit-wipet — sichtbar z. B. wenn ein Container-Recreate danach mit
+   "iptables: No chain/target/match by that name" failed. #}
+{% for firewall_table in _firewall | default([]) %}
+flush table {{ firewall_table.table.family }} {{ firewall_table.table.name }}
+{% endfor %}
 
 {% for firewall_table in _firewall | default([]) %}
 table {{ firewall_table.table.family }} {{ firewall_table.table.name }} {

--- a/roles/firewall/templates/etc/nftables.conf.j2
+++ b/roles/firewall/templates/etc/nftables.conf.j2
@@ -8,8 +8,13 @@
    hier `flush ruleset`, was alle Tables anderer Quellen (Docker
    iptables-nft, kube-proxy, manuelle Entries) bei jedem Config-Reload
    mit-wipet — sichtbar z. B. wenn ein Container-Recreate danach mit
-   "iptables: No chain/target/match by that name" failed. #}
+   "iptables: No chain/target/match by that name" failed. Der leere
+   `table { }`-Stub vor dem Flush ist ein No-op wenn die Table bereits
+   existiert, legt sie auf Fresh-Hosts an und macht `flush table` damit
+   beim ersten Apply nicht-failable. #}
 {% for firewall_table in _firewall | default([]) %}
+table {{ firewall_table.table.family }} {{ firewall_table.table.name }} {
+}
 flush table {{ firewall_table.table.family }} {{ firewall_table.table.name }}
 {% endfor %}
 

--- a/roles/logging/tasks/rsyslog.yml
+++ b/roles/logging/tasks/rsyslog.yml
@@ -60,7 +60,8 @@
   ansible.builtin.include_role:
       name: arillso.system.systemd
       tasks_from: service
-  become: true
+      apply:
+          become: true
   vars:
       systemd_services:
           - name: rsyslog

--- a/roles/network/tasks/resolv.yml
+++ b/roles/network/tasks/resolv.yml
@@ -21,7 +21,8 @@
         ansible.builtin.include_role:
             name: arillso.system.systemd
             tasks_from: service
-        become: true
+            apply:
+                become: true
         vars:
             systemd_services:
                 - name: systemd-resolved

--- a/roles/packages/tasks/unattended_upgrades.yml
+++ b/roles/packages/tasks/unattended_upgrades.yml
@@ -83,7 +83,8 @@
         ansible.builtin.include_role:
             name: arillso.system.systemd
             tasks_from: service
-        become: true
+            apply:
+                become: true
         vars:
             systemd_services:
                 - name: unattended-upgrades
@@ -102,7 +103,8 @@
         ansible.builtin.include_role:
             name: arillso.system.systemd
             tasks_from: service
-        become: true
+            apply:
+                become: true
         vars:
             systemd_services:
                 - name: unattended-upgrades


### PR DESCRIPTION
## Summary

Three bugfixes across the collection that surfaced in production:

- **firewall**: replace `flush ruleset` with scoped `flush table <family> <name>` for each managed table, both in the rendered `nftables.conf` and in the systemd `ExecStop` override. The global flush wiped Docker's iptables-nft chains (and any other foreign nftables state) on every reload/restart, causing container recreates to fail with `iptables: No chain/target/match by that name`.
- **access/users**: only set `append` when `groups` is defined on the item — `ansible.builtin.user` warns "'append' is set, but no 'groups' are specified" today and turns it into an error in Ansible 2.14.
- **include_role become**: move `become: true` inside `apply:` for the four call sites that include the `systemd` role (`access/ssh_server`, `logging/rsyslog`, `network/resolv`, `packages/unattended_upgrades`). Directly on `include_role` it only escalated the include itself, not the tasks inside the included role, so `systemctl` calls ran unprivileged.

## Test plan

- [ ] Run firewall role on a host with Docker installed, recreate a container after the run, confirm Docker iptables chains survive.
- [ ] Confirm `_firewall` ExecStop override renders one `nft flush table …` line per managed table (and no naked `nft flush ruleset`).
- [ ] Run access role with a user that has no `groups` set, confirm no "'append' is set" warning.
- [ ] Run access/ssh_server, logging/rsyslog, network/resolv, packages/unattended_upgrades on a host where the play does not globally `become`, confirm the `systemd` role's `systemctl` tasks succeed.
- [ ] `ansible-lint` clean.