### PR TITLE
Release 1.1.5: role hygiene — scoped nftables flush, user append, include_role become

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.5] - 2026-05-15
+
+### Fixed
+
+- `firewall` role: scope nftables flush to managed tables instead of running
+  a global `flush ruleset`. Both the rendered `/etc/nftables.conf` and the
+  systemd-override `ExecStop` previously wiped *all* nftables state on each
+  reload/restart, including tables managed by other sources (Docker's
+  iptables-nft `ip nat` / `ip filter` chains, kube-proxy, manually added
+  entries). Container recreates after a firewall handler run failed with
+  `iptables: No chain/target/match by that name`. The template now emits an
+  empty `table <family> <name> { }` stub before each `flush table` so the
+  first apply on a fresh host succeeds, and the systemd `ExecStop` flush
+  commands are prefixed with `-` so systemd treats a missing table on stop
+  as non-fatal
+- `access` role: only set `append` on the `ansible.builtin.user` module when
+  `groups` is also defined for the entry. The previous unconditional
+  `append` emitted the warning `'append' is set, but no 'groups' are
+  specified` and would have failed hard once that warning is promoted to an
+  error in `ansible-core` 2.14
+- All `include_role` calls to the `systemd` role now pass `become: true`
+  through `apply:` (in `access/ssh_server`, `logging/rsyslog`,
+  `network/resolv`, and both `packages/unattended_upgrades` branches).
+  `become` directly on `ansible.builtin.include_role` only escalates the
+  include itself, not the tasks inside the included role, so `systemctl`
+  tasks ran unprivileged and failed on hosts where the play did not
+  globally `become`
+
 ## [1.1.4] - 2026-05-02
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: system
-version: 1.1.4
+version: 1.1.5
 readme: README.md
 
 authors:


### PR DESCRIPTION
## Summary

Patch release covering the bug fixes merged in #131.

- **firewall**: scope nftables flush to managed tables (`flush ruleset` → per-table `flush table`), emit an empty `table { }` stub before each flush so first-apply on a fresh host succeeds, and prefix the systemd `ExecStop` flush commands with `-` so a missing table on stop is non-fatal.
- **access**: only set `append` on `ansible.builtin.user` when `groups` is also defined for the entry — avoids the `'append' is set, but no 'groups' are specified` warning that becomes a hard error in `ansible-core` 2.14.
- **include_role + systemd**: pass `become: true` via `apply:` for all four call sites (`access/ssh_server`, `logging/rsyslog`, `network/resolv`, `packages/unattended_upgrades`) so privilege escalation propagates to the included role's `systemctl` tasks.

Bumps `galaxy.yml` to `1.1.5` and moves the change set into the matching `CHANGELOG.md` section. After merge, push tag `1.1.5` to trigger the publish workflow.

## Test plan

- [ ] CI green (ansible-lint, yamllint, sanity, unit, build).
- [ ] CHANGELOG `[1.1.5]` section renders correctly and matches the `galaxy.yml` version.
- [ ] After merge: `git tag 1.1.5 && git push origin 1.1.5` triggers `publish.yml` → Galaxy publish + GitHub release with changelog notes.