### PR TITLE
fix(access): parenthesize runas spec in sudoers template + release 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.6] - 2026-05-17
+
+### Fixed
+
+- `access` role: wrap the `runas` field in the rendered sudoers file in
+  parentheses, as required by the sudoers(5) grammar
+  (`Runas_Spec ::= '(' Runas_List? (':' Runas_List)? ')'`). The
+  `sudoer.j2` template emitted `host=runas` instead of `host=(runas)`,
+  so every entry created from `access_sudoers` was syntactically
+  invalid: `visudo -cf` rejected the file and the templating task
+  failed at deploy time (`access_validate_sudoers` defaults to `true`).
+  Hosts that disabled the validate hook would have silently shipped a
+  broken sudoers drop-in. Both the user and group branches now render
+  `=({{ runas | default('ALL') }})`, so existing example configs like
+  `runas: ALL` produce valid syntax without changes. The bug was
+  introduced in the access-role rewrite (`ab1b3be`, 2026-01-14) and
+  affects all 1.1.x releases up to and including 1.1.5
+
 ## [1.1.5] - 2026-05-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `=({{ runas | default('ALL') }})`, so existing example configs like
   `runas: ALL` produce valid syntax without changes. The bug was
   introduced in the access-role rewrite (`ab1b3be`, 2026-01-14) and
-  affects all 1.1.x releases up to and including 1.1.5
+  affects all 1.1.x releases up to and including 1.1.5.
 
 ## [1.1.5] - 2026-05-15
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: arillso
 name: system
-version: 1.1.5
+version: 1.1.6
 readme: README.md
 
 authors:

--- a/roles/access/templates/etc/sudoers.d/sudoer.j2
+++ b/roles/access/templates/etc/sudoers.d/sudoer.j2
@@ -3,8 +3,8 @@
 
 {% if _access_sudoer_item.user is defined %}
 # User: {{ _access_sudoer_item.user }}
-{{ _access_sudoer_item.user }} {{ _access_sudoer_item.hosts | default('ALL') }}={{ _access_sudoer_item.runas | default('ALL') }}{% if _access_sudoer_item.nopasswd | default(false) %} NOPASSWD:{% endif %}{% if _access_sudoer_item.setenv | default(false) %} SETENV:{% endif %} {{ _access_sudoer_item.commands | default('ALL') }}
+{{ _access_sudoer_item.user }} {{ _access_sudoer_item.hosts | default('ALL') }}=({{ _access_sudoer_item.runas | default('ALL') }}){% if _access_sudoer_item.nopasswd | default(false) %} NOPASSWD:{% endif %}{% if _access_sudoer_item.setenv | default(false) %} SETENV:{% endif %} {{ _access_sudoer_item.commands | default('ALL') }}
 {% elif _access_sudoer_item.group is defined %}
 # Group: {{ _access_sudoer_item.group }}
-%{{ _access_sudoer_item.group }} {{ _access_sudoer_item.hosts | default('ALL') }}={{ _access_sudoer_item.runas | default('ALL') }}{% if _access_sudoer_item.nopasswd | default(false) %} NOPASSWD:{% endif %}{% if _access_sudoer_item.setenv | default(false) %} SETENV:{% endif %} {{ _access_sudoer_item.commands | default('ALL') }}
+%{{ _access_sudoer_item.group }} {{ _access_sudoer_item.hosts | default('ALL') }}=({{ _access_sudoer_item.runas | default('ALL') }}){% if _access_sudoer_item.nopasswd | default(false) %} NOPASSWD:{% endif %}{% if _access_sudoer_item.setenv | default(false) %} SETENV:{% endif %} {{ _access_sudoer_item.commands | default('ALL') }}
 {% endif %}


### PR DESCRIPTION
## Summary

- Fix `access` role: `sudoer.j2` template rendered `host=runas` instead of `host=(runas)`, which violates the sudoers(5) grammar (`Runas_Spec ::= '(' Runas_List? (':' Runas_List)? ')'`). Every drop-in produced from `access_sudoers` was syntactically invalid — `visudo -cf` rejected the file and the templating task failed at deploy time (validate hook is on by default); hosts that disabled the hook silently shipped a broken `/etc/sudoers.d/<name>`. The bug was introduced in the access-role rewrite (`ab1b3be`, 2026-01-14) and affects every 1.1.x release up to and including 1.1.5.
- Release 1.1.6: `galaxy.yml` bumped and `CHANGELOG.md` entry moved from `[Unreleased]` to a dated `[1.1.6]` section so the publish workflow can extract the release notes on tag push.

## Test plan

- [ ] MegaLinter (`ci.yml`) green
- [ ] ansible-lint clean on `roles/access/`
- [ ] Local smoke: render `sudoer.j2` with a minimal `access_sudoers` entry and validate the result with `visudo -cf`
- [ ] Confirm `access_validate_sudoers: true` no longer rejects the rendered file