### PR TITLE
fix(tuning): compare swap size via stat instead of swapon payload

### DIFF
--- a/roles/tuning/tasks/swap.yml
+++ b/roles/tuning/tasks/swap.yml
@@ -60,10 +60,9 @@
         ansible.builtin.set_fact:
             swap_file_active: "{{ tuning_swap_file_path in active_swaps.stdout }}"
             current_swap_size: >-
-                {%- for line in active_swaps.stdout_lines -%}
-                {%- if tuning_swap_file_path in line -%}
-                {{ (line.split()[1] | int / 1024 / 1024) | int }}{%- endif -%}
-                {%- endfor -%}
+                {%- if swap_file_stat.stat.exists -%}
+                {{ (swap_file_stat.stat.size / 1024 / 1024) | int }}
+                {%- endif -%}
 
 - name: Create or resize swap file
   block:


### PR DESCRIPTION
## Summary

- `swap.yml` derived `current_swap_size` from `swapon --show=SIZE`, which reports the swap **payload** (file size minus one page for the swap header). A 2048 MiB file reports 2147479552 bytes → 2047 MiB after integer division, so the size check `current_swap_size != tuning_swap_file_size_mb | string` was always true.
- Result: every Ansible run produced a fresh `/swapfile.backup.<epoch>` and rebuilt the swapfile. On hosts that run ansible-pull on a 15-minute timer, dozens of GiB of leftover backups accumulated until the disk filled up.
- Fix: compare against `swap_file_stat.stat.size` (the nominal on-disk size from the existing `stat` task). The `swap_file_active` flag still derives from `swapon` output, so the activation logic is unchanged.

## Test plan

- [ ] Run the `tuning` role twice on a host with an existing correctly-sized swapfile → second run must show 0 changes, no new `/swapfile.backup.*` entry.
- [ ] Run on a host without a swapfile → swap is created and activated.
- [ ] Run on a host with a wrong-sized swapfile → swap is resized, exactly one backup is produced.