### PR TITLE
refactor(roles): scope become to least privilege

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- All roles: consolidate privilege escalation on the principle of least
+  privilege. `become` now lives on the single privileged task (the
+  `ansible.builtin.systemd` task inside the shared `systemd` sub-role),
+  and callers no longer re-declare it. Removed six redundant escalation
+  declarations that broadened the `become` surface without effect: five
+  `apply: become: true` blocks on the `systemd` includes (one each in
+  the `access`, `logging` and `network` roles, and two in the
+  `packages` role — the included task already escalates), plus the
+  `block`-level `become: true` in the `network` role (every task in
+  `resolv.yml`/`netplan.yml` escalates on its own). `apply:`/`block:` escalation applies `become` to *every*
+  task in scope; task-level escalation applies it only where it is
+  needed. No functional change — the privileged tasks still run as root.
+
 ## [1.1.6] - 2026-05-17
 
 ### Fixed

--- a/roles/access/tasks/ssh_server.yml
+++ b/roles/access/tasks/ssh_server.yml
@@ -19,8 +19,6 @@
   ansible.builtin.include_role:
       name: arillso.system.systemd
       tasks_from: service
-      apply:
-          become: true
   vars:
       systemd_services:
           - name: "{{ _access_ssh_service_name }}"

--- a/roles/logging/tasks/rsyslog.yml
+++ b/roles/logging/tasks/rsyslog.yml
@@ -60,8 +60,6 @@
   ansible.builtin.include_role:
       name: arillso.system.systemd
       tasks_from: service
-      apply:
-          become: true
   vars:
       systemd_services:
           - name: rsyslog

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Manage network configuration
-  become: true
   block:
       - name: Manage DNS configuration
         ansible.builtin.include_tasks: resolv.yml

--- a/roles/network/tasks/resolv.yml
+++ b/roles/network/tasks/resolv.yml
@@ -21,8 +21,6 @@
         ansible.builtin.include_role:
             name: arillso.system.systemd
             tasks_from: service
-            apply:
-                become: true
         vars:
             systemd_services:
                 - name: systemd-resolved

--- a/roles/packages/tasks/unattended_upgrades.yml
+++ b/roles/packages/tasks/unattended_upgrades.yml
@@ -83,8 +83,6 @@
         ansible.builtin.include_role:
             name: arillso.system.systemd
             tasks_from: service
-            apply:
-                become: true
         vars:
             systemd_services:
                 - name: unattended-upgrades
@@ -103,8 +101,6 @@
         ansible.builtin.include_role:
             name: arillso.system.systemd
             tasks_from: service
-            apply:
-                become: true
         vars:
             systemd_services:
                 - name: unattended-upgrades


### PR DESCRIPTION
## Summary

Vereinheitlicht die Privilege-Escalation in der Collection nach dem Prinzip **least privilege**. Auslöser war [#139](https://github.com/arillso/ansible.system/pull/139) (versehentlich geschlossener Fork-Sync), der an einer Stelle ein redundantes `become` entfernen wollte — hier konsequent auf alle betroffenen Stellen angewendet, mit dem Prinzip dahinter.

`become` lebt jetzt auf der **einzelnen privilegierten Task** (der `ansible.builtin.systemd`-Task in der geteilten `systemd`-Sub-Rolle). Aufrufer deklarieren es nicht erneut. `apply:`/`block:`-Escalation hängt `become` an *jede* Task im Scope — das ist die gröbere Variante als das bereits vorhandene Task-Level-`become`.

## Was entfernt wurde (5 redundante Deklarationen, 0 funktionale Änderung)

- `access`, `logging`, `network`, `packages`: `apply: become: true` an den `systemd`-Includes (`service.yml` eskaliert seine systemd-Task bereits selbst)
- `network`: `block`-level `become: true` um `resolv.yml`/`netplan.yml` (jede Task in beiden Dateien eskaliert einzeln)

## Bewusst nicht angefasst

`firewall`, `thermal`, `tuning` verlassen sich bereits korrekt auf das `become` der Sub-Rolle und ergänzen keins — genau das gewünschte Pattern.

## Test plan

- [x] `ansible-lint` (production profile): 0 failures, 0 warnings auf 82 Dateien
- [x] Verifiziert: keine `apply: become` mehr an systemd-Includes übrig
- [x] Verifiziert: alle Tasks in `resolv.yml`/`netplan.yml` tragen Task-Level-`become`