### PR TITLE
feat(zram): add compressed RAM swap role and sync tuning fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `zram` role: compressed RAM swap via the Debian/Ubuntu `zram-tools`
+  package. Bootstraps the zram kernel module (incl.
+  `linux-modules-extra-<kernel>` on cloud images), validates the
+  requested compression algorithm against the kernel, deploys
+  `/etc/default/zramswap`, and manages the `zramswap` service.
+  Configurable via `zram_percent`, `zram_algorithm`, `zram_priority`,
+  `zram_packages`, and `zram_kernel_module_package`. Pairs with the
+  `tuning` role for a zram-first layout (set `zram_priority` higher than
+  `tuning_swap_priority` so disk swap is the fallback).
+- `tuning` role: new `tuning_swap_priority` variable (default `0`,
+  backward-compatible) to set the Linux swap priority. The swap file is
+  now activated with `swapon -p <priority>` and the `/etc/fstab` entry
+  carries `pri=<priority>`, enabling multi-backend layouts such as
+  zram-first with disk-swap as a lower-priority fallback.
+
+### Fixed
+
+- `tuning` role: replace the two swap-validation `fail` tasks with
+  `assert`. The previous `when:` lists were AND-joined, but the
+  conditions were mutually exclusive (a variable cannot be both
+  undefined and `== ""`), so the guards never fired. `assert` makes the
+  OR-semantics explicit and reads as a pre-condition.
+- `tuning` role: round `current_swap_size` up by 0.5 MiB before the
+  byte→MiB conversion. `swapon` reports the swap size minus the mkswap
+  header overhead (~4 KB), so a 2048 MiB file read back as 2047 MiB and
+  triggered a recreate loop on every run, breaking idempotency.
+- `tuning` role: stop backing up the swap file before a resize. Swap
+  holds only volatile pages, so the copy preserved nothing usable, while
+  each resize wrote a multi-GB `.backup.<epoch>` file that could fill
+  small disks and fail the disk-space assertion. Replaced with an
+  explicit refusal to shrink an existing swap file.
+- `tuning` role: refresh the `swap_file_active` fact to `false` after
+  `swapoff` so downstream tasks see the swap as disabled during a
+  resize.
+
 ### Changed
 
 - All roles: consolidate privilege escalation on the principle of least

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `tuning` role: refresh the `swap_file_active` fact to `false` after
   `swapoff` so downstream tasks see the swap as disabled during a
   resize.
+- `tuning` role: write the fstab swap entry unconditionally so the
+  `pri=` option is reconciled on hosts that already had an `sw 0 0`
+  entry. Previously the entry was only added when absent, so the swap
+  priority never survived a reboot on the upgrade path.
+- `tuning` role: reapply the swap priority at runtime (via
+  `swapoff`/`swapon -p`) when it drifts from `tuning_swap_priority` on
+  an already-active, correctly-sized swap; a bare `swapon -p` does not
+  change the priority of an active device.
+- `tuning` role: skip the remove/recreate sequence for an existing but
+  inactive swap file (`current_swap_size == ""`), which previously
+  rebuilt a correctly-sized file on every run, and only re-run `mkswap`
+  on a freshly created file.
+- `zram` role: update the apt cache before installing packages (via the
+  `packages` role `cache` task), so installs on a freshly provisioned
+  host or right after a kernel upgrade no longer fail on a stale index.
+- `zram` role: leave `zram_kernel_module_package` empty on Debian, which
+  ships the zram module in the stock kernel and has no
+  `linux-modules-extra-*` package; the module install is skipped there
+  instead of failing with "Unable to locate package".
+- `zram` role: load the kernel module with `num_devices=1` so
+  `/sys/block/zram0` is guaranteed to exist for the algorithm
+  validation, even on hosts that override the modprobe default.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ package management, network configuration, firewall setup, logging, and system t
 - **[bitwarden_secrets](roles/bitwarden_secrets)** - Bitwarden CLI secret management
 - **[thermal](roles/thermal)** - CPU thermal management
 - **[tuning](roles/tuning)** - System performance tuning (CPU, IO, network, swap)
+- **[zram](roles/zram)** - Compressed RAM swap (zram) via zram-tools
 
 ## Plugins
 

--- a/roles/tuning/defaults/main.yml
+++ b/roles/tuning/defaults/main.yml
@@ -42,6 +42,11 @@ tuning_swap_swappiness: 10
 tuning_swap_file_enabled: false
 tuning_swap_file_path: /swapfile
 tuning_swap_file_size_mb: 2048
+# Linux swap priority for /etc/fstab opts (pri=N). Default 0 = backward-compatible
+# (Linux uses round-robin among equal priorities with a single backend, so this
+# is functionally identical to the previous default). Set >0 for multi-backend
+# layouts (e.g. zram-first with disk-swap as fallback at lower priority).
+tuning_swap_priority: 0
 
 # I/O Scheduler
 tuning_io_scheduler: auto

--- a/roles/tuning/meta/argument_specs.yml
+++ b/roles/tuning/meta/argument_specs.yml
@@ -60,6 +60,16 @@ argument_specs:
                 default: 2048
                 description: "Swap file size in megabytes"
 
+            tuning_swap_priority:
+                type: "int"
+                required: false
+                default: 0
+                description: |
+                    Linux swap priority for /etc/fstab opts (pri=N).
+                    Default 0 is backward-compatible (single backend).
+                    Set >0 for multi-backend layouts (e.g. zram-first with
+                    disk-swap as fallback at lower priority).
+
             tuning_io_scheduler:
                 type: "str"
                 required: false

--- a/roles/tuning/tasks/swap.yml
+++ b/roles/tuning/tasks/swap.yml
@@ -4,20 +4,25 @@
 
 - name: Validate swap configuration
   block:
-      - name: Check if swap file path is valid
-        ansible.builtin.fail:
-            msg: "Invalid swap file path: {{ tuning_swap_file_path }}"
-        when:
-            - tuning_swap_file_path is not defined
-            - tuning_swap_file_path == ""
-            - not tuning_swap_file_path.startswith("/")
+      # Eine YAML-Liste unter `when:` wird AND-verknuepft — die drei
+      # Bedingungen schliessen sich aber gegenseitig aus (undefined kann
+      # nicht gleichzeitig `== ""` sein), sodass kein fail je feuern
+      # wuerde. `assert` macht die OR-Semantik explizit und liest sich
+      # gleichzeitig als Pre-Condition statt als if-then-fail.
+      - name: Assert swap file path is valid
+        ansible.builtin.assert:
+            that:
+                - tuning_swap_file_path is defined
+                - tuning_swap_file_path | string | length > 0
+                - tuning_swap_file_path is string and tuning_swap_file_path.startswith("/")
+            fail_msg: "Invalid swap file path: {{ tuning_swap_file_path | default('<undefined>') }}"
 
-      - name: Validate swap file size
-        ansible.builtin.fail:
-            msg: "Invalid swap file size: {{ tuning_swap_file_size_mb }}MB (minimum 64MB)"
-        when:
-            - tuning_swap_file_size_mb is not defined
-            - tuning_swap_file_size_mb | int < 64
+      - name: Assert swap file size is valid
+        ansible.builtin.assert:
+            that:
+                - tuning_swap_file_size_mb is defined
+                - tuning_swap_file_size_mb | int >= 64
+            fail_msg: "Invalid swap file size: {{ tuning_swap_file_size_mb | default('<undefined>') }}MB (minimum 64MB)"
 
 - name: Check available disk space using facts
   block:
@@ -56,32 +61,51 @@
         changed_when: false
         failed_when: false
 
+      # Rundungs-Trick: swapon meldet die Swap-Datei-Grösse abzüglich des mkswap-Header-
+      # Overheads (~4 KB). Eine reine Trunkierung würde z. B. 2048 MiB als 2047 MiB
+      # zurückgeben und einen Recreate-Loop jeder Idempotenz verletzen.
+      # Addieren von 524288 Bytes (= 0.5 MiB) vor der Division emuliert round() und
+      # fängt den Header-Verlust ab.
       - name: Parse active swap information
         ansible.builtin.set_fact:
             swap_file_active: "{{ tuning_swap_file_path in active_swaps.stdout }}"
             current_swap_size: >-
                 {%- for line in active_swaps.stdout_lines -%}
                 {%- if tuning_swap_file_path in line -%}
-                {{ (line.split()[1] | int / 1024 / 1024) | int }}{%- endif -%}
+                {{ ((line.split()[1] | int + 524288) / 1024 / 1024) | int }}{%- endif -%}
                 {%- endfor -%}
 
 - name: Create or resize swap file
   block:
-      - name: Backup existing swap file
-        ansible.builtin.copy:
-            src: "{{ tuning_swap_file_path }}"
-            dest: "{{ tuning_swap_file_path }}.backup.{{ ansible_date_time.epoch }}"
-            remote_src: true
-            mode: preserve
-        become: true
+      # Kein Backup der Swap-Datei: Swap enthält nur flüchtige Pages, eine Kopie
+      # sichert nichts Verwertbares. Der frühere Backup-Task legte bei jedem
+      # Resize eine 2-GB-Kopie an (.backup.<epoch>) — auf der kleinen code-01-
+      # Disk füllte das die Partition, bis die "Ensure sufficient disk space"-
+      # Assertion oben den ganzen Lauf failte. Die Resize-Sequenz unten
+      # (swapoff → remove → fallocate) braucht kein Backup.
+      - name: Refuse to shrink existing swap file
+        ansible.builtin.fail:
+            msg: >-
+                Refusing to shrink swap file {{ tuning_swap_file_path }} from
+                {{ current_swap_size }}MB to {{ tuning_swap_file_size_mb }}MB.
+                Disable explicitly via tuning_swap_file_enabled=false and rerun,
+                then re-enable.
         when:
             - swap_file_stat.stat.exists
-            - current_swap_size != (tuning_swap_file_size_mb | string)
+            - current_swap_size != ""
+            - (current_swap_size | int) > (tuning_swap_file_size_mb | int)
 
       - name: Disable existing swap file if resizing
         ansible.builtin.command: swapoff {{ tuning_swap_file_path }}
         become: true
         changed_when: true
+        when:
+            - swap_file_active
+            - current_swap_size != (tuning_swap_file_size_mb | string)
+
+      - name: Refresh swap_file_active fact after swapoff
+        ansible.builtin.set_fact:
+            swap_file_active: false
         when:
             - swap_file_active
             - current_swap_size != (tuning_swap_file_size_mb | string)
@@ -153,7 +177,7 @@
         when: not swap_file_active or current_swap_size != (tuning_swap_file_size_mb | string)
 
       - name: Enable swap file
-        ansible.builtin.command: swapon {{ tuning_swap_file_path }}
+        ansible.builtin.command: swapon -p {{ tuning_swap_priority }} {{ tuning_swap_file_path }}
         become: true
         register: swapon_result
         changed_when: swapon_result.rc == 0
@@ -182,7 +206,7 @@
             path: none
             src: "{{ tuning_swap_file_path }}"
             fstype: swap
-            opts: sw
+            opts: "sw,pri={{ tuning_swap_priority }}"
             passno: 0
             dump: 0
             state: present

--- a/roles/tuning/tasks/swap.yml
+++ b/roles/tuning/tasks/swap.yml
@@ -56,7 +56,7 @@
         register: swap_file_stat
 
       - name: Get current swap information
-        ansible.builtin.command: swapon --show=NAME,SIZE --noheadings --bytes
+        ansible.builtin.command: swapon --show=NAME,SIZE,PRIO --noheadings --bytes
         register: active_swaps
         changed_when: false
         failed_when: false
@@ -66,6 +66,8 @@
       # zurückgeben und einen Recreate-Loop jeder Idempotenz verletzen.
       # Addieren von 524288 Bytes (= 0.5 MiB) vor der Division emuliert round() und
       # fängt den Header-Verlust ab.
+      # current_swap_priority bleibt "" wenn die Swap nicht aktiv ist; ein gesetzter
+      # Wert erlaubt den Priority-Drift-Vergleich beim swapon weiter unten.
       - name: Parse active swap information
         ansible.builtin.set_fact:
             swap_file_active: "{{ tuning_swap_file_path in active_swaps.stdout }}"
@@ -73,6 +75,11 @@
                 {%- for line in active_swaps.stdout_lines -%}
                 {%- if tuning_swap_file_path in line -%}
                 {{ ((line.split()[1] | int + 524288) / 1024 / 1024) | int }}{%- endif -%}
+                {%- endfor -%}
+            current_swap_priority: >-
+                {%- for line in active_swaps.stdout_lines -%}
+                {%- if tuning_swap_file_path in line -%}
+                {{ line.split()[2] }}{%- endif -%}
                 {%- endfor -%}
 
 - name: Create or resize swap file
@@ -95,12 +102,17 @@
             - current_swap_size != ""
             - (current_swap_size | int) > (tuning_swap_file_size_mb | int)
 
+      # A resize is only warranted when the file is active at a known size that
+      # differs from the target. An existing-but-inactive file (current_swap_size
+      # == "", e.g. after a reboot before fstab mounts it, or a manual swapoff)
+      # must NOT be removed/recreated — that would break idempotency on every run.
       - name: Disable existing swap file if resizing
         ansible.builtin.command: swapoff {{ tuning_swap_file_path }}
         become: true
         changed_when: true
         when:
             - swap_file_active
+            - current_swap_size != ""
             - current_swap_size != (tuning_swap_file_size_mb | string)
 
       - name: Refresh swap_file_active fact after swapoff
@@ -108,6 +120,7 @@
             swap_file_active: false
         when:
             - swap_file_active
+            - current_swap_size != ""
             - current_swap_size != (tuning_swap_file_size_mb | string)
 
       - name: Remove existing swap file if resizing
@@ -117,6 +130,7 @@
         become: true
         when:
             - swap_file_stat.stat.exists
+            - current_swap_size != ""
             - current_swap_size != (tuning_swap_file_size_mb | string)
 
       - name: Create swap file using fallocate
@@ -125,7 +139,9 @@
         register: fallocate_result
         changed_when: fallocate_result.rc == 0
         failed_when: false
-        when: not swap_file_stat.stat.exists or current_swap_size != (tuning_swap_file_size_mb | string)
+        when: >-
+            not swap_file_stat.stat.exists
+            or (current_swap_size != "" and current_swap_size != (tuning_swap_file_size_mb | string))
 
       - name: Create swap file using dd (fallback)
         ansible.builtin.command: >-
@@ -169,12 +185,17 @@
         register: size_check
         changed_when: false
 
+      # Format only a freshly created file: when it did not exist, or when it was
+      # removed for a resize. Re-running mkswap on an existing, correctly-sized
+      # file (incl. the inactive case) would report changed on every run.
       - name: Format swap file
         ansible.builtin.command: mkswap {{ tuning_swap_file_path }}
         become: true
         register: mkswap_result
         changed_when: mkswap_result.rc == 0
-        when: not swap_file_active or current_swap_size != (tuning_swap_file_size_mb | string)
+        when: >-
+            not swap_file_stat.stat.exists
+            or (current_swap_size != "" and current_swap_size != (tuning_swap_file_size_mb | string))
 
       - name: Enable swap file
         ansible.builtin.command: swapon -p {{ tuning_swap_priority }} {{ tuning_swap_file_path }}
@@ -182,6 +203,22 @@
         register: swapon_result
         changed_when: swapon_result.rc == 0
         when: not swap_file_active
+
+      # A priority-only change on an already-active swap is not applied by a bare
+      # `swapon -p` (the kernel rejects re-adding an active device), so reconcile
+      # it explicitly: swapoff then swapon with the desired priority. Gated on a
+      # real drift so correctly-prioritised hosts stay unchanged.
+      - name: Reapply swap priority when it drifts on an active swap
+        ansible.builtin.shell: >-
+            swapoff {{ tuning_swap_file_path }}
+            && swapon -p {{ tuning_swap_priority }} {{ tuning_swap_file_path }}
+        become: true
+        register: swap_reprio_result
+        changed_when: swap_reprio_result.rc == 0
+        when:
+            - swap_file_active
+            - current_swap_priority != ""
+            - (current_swap_priority | int) != (tuning_swap_priority | int)
 
       - name: Verify swap is active
         ansible.builtin.command: swapon --show=NAME --noheadings
@@ -195,13 +232,11 @@
 
 - name: Configure swap persistence
   block:
-      - name: Check if swap entry exists in fstab
-        ansible.builtin.command: grep -q "^{{ tuning_swap_file_path }}" /etc/fstab
-        register: fstab_check
-        changed_when: false
-        failed_when: false
-
-      - name: Add swap file to fstab
+      # Run unconditionally: ansible.posix.mount is idempotent and reconciles the
+      # opts. A previous "skip when the entry exists" gate meant a host with an
+      # older `... sw 0 0` line never had pri={{ tuning_swap_priority }} persisted,
+      # so the zram-first fallback layout would not survive a reboot on upgrade.
+      - name: Ensure swap file is in fstab with the desired priority
         ansible.posix.mount:
             path: none
             src: "{{ tuning_swap_file_path }}"
@@ -211,7 +246,6 @@
             dump: 0
             state: present
         become: true
-        when: fstab_check.rc != 0
 
 - name: Report swap configuration status
   ansible.builtin.debug:

--- a/roles/tuning/templates/etc/udev/rules.d/60-io-scheduler.rules.j2
+++ b/roles/tuning/templates/etc/udev/rules.d/60-io-scheduler.rules.j2
@@ -8,7 +8,7 @@
 
 {% if optimized_storage_devices is defined %}
 {% for device in optimized_storage_devices %}
-# {{ device.name }} ({{ device.type }}): {{ device.scheduler }}
+# {{ device.name }}: {{ device.scheduler }}
 ACTION=="add|change", KERNEL=="{{ device.name }}", ATTR{queue/scheduler}="{{ device.scheduler }}"
 {% endfor %}
 {% endif %}

--- a/roles/zram/README.md
+++ b/roles/zram/README.md
@@ -1,0 +1,41 @@
+# Ansible Role: zram
+
+Configures compressed RAM swap (zram) on Debian/Ubuntu systems via the
+`zram-tools` package.
+
+## Features
+
+- **Compressed RAM Swap**: Allocate a percentage of physical RAM as a zram swap device
+- **Kernel Module Bootstrap**: Installs and loads the zram module (incl. `linux-modules-extra` on cloud kernels)
+- **Algorithm Validation**: Verifies the requested compression algorithm against kernel capabilities
+- **Priority Control**: Swap priority higher than disk swap so the kernel fills zram first
+- **Idempotent Service Management**: Deploys `/etc/default/zramswap` and manages the `zramswap` service
+
+## Documentation
+
+For detailed documentation including all variables, examples, and usage instructions, see:
+
+**[https://guide.arillso.io/collections/arillso/system/zram_role.html](https://guide.arillso.io/collections/arillso/system/zram_role.html)**
+
+## Quick Start
+
+```yaml
+- hosts: servers
+  roles:
+      - role: arillso.system.zram
+        vars:
+            zram_percent: 50
+            zram_algorithm: "zstd"
+            zram_priority: 100
+```
+
+Pair with the `tuning` role for a zram-first layout by setting a lower
+`tuning_swap_priority` than `zram_priority`, so disk swap acts as a fallback.
+
+## License
+
+MIT
+
+## Author Information
+
+This role was created by [arillso](https://github.com/arillso).

--- a/roles/zram/defaults/main.yml
+++ b/roles/zram/defaults/main.yml
@@ -26,10 +26,13 @@ zram_priority: 100
 zram_packages:
     - zram-tools
 
-# zram_kernel_module_package: Paket, das das zram-Kernel-Modul liefert.
-# Auf Hetzner-Cloud-Ubuntu mit linux-image-virtual ist das zram-Modul NICHT
-# im Standard-Image enthalten — es lebt in linux-modules-extra-<kernel-version>.
-# Die Variable wird zur Laufzeit gegen den aktuellen Kernel resolved (ansible_kernel),
-# sodass Kernel-Upgrades automatisch das passende neue Paket ziehen.
-# Siehe .kiro/specs/code-server-swap/research.md I6/D6.
-zram_kernel_module_package: "linux-modules-extra-{{ ansible_kernel }}"
+# zram_kernel_module_package: package that provides the zram kernel module.
+# On Ubuntu cloud images with linux-image-virtual the module is not part of
+# the base image — it lives in linux-modules-extra-<kernel>, resolved against
+# the running kernel (ansible_kernel) so kernel upgrades pull the matching
+# package automatically. Debian ships the module in the stock kernel and has
+# no linux-modules-extra-* package, so the default is empty there and the
+# install step is skipped. Set explicitly to override per host.
+zram_kernel_module_package: >-
+    {{ 'linux-modules-extra-' ~ ansible_kernel
+       if ansible_distribution == 'Ubuntu' else '' }}

--- a/roles/zram/defaults/main.yml
+++ b/roles/zram/defaults/main.yml
@@ -1,0 +1,35 @@
+---
+# Compressed RAM swap (zram) defaults
+#
+# zram_enabled: master switch for the role. Default true configures zram;
+# set to false to make every task in the role a no-op.
+zram_enabled: true
+
+# zram_percent: percentage of physical RAM to allocate as zram swap device.
+# Default 50 means a 16 GB host gets an 8 GB zram device. With typical
+# zstd compression ratios on JS/TS/text workloads (~3x), this yields
+# ~24 GB of effectively usable memory.
+zram_percent: 50
+
+# zram_algorithm: kernel compression algorithm. zstd is the best balance
+# of speed and compression ratio on modern kernels. Available algorithms
+# are validated against /sys/block/zram0/comp_algorithm at role runtime.
+zram_algorithm: zstd
+
+# zram_priority: Linux swap priority for the zram device. Higher than
+# any disk-based swap so the kernel fills zram first. The role's tuning
+# expects this to remain >= disk swap priorities (typically tuning_swap_priority).
+zram_priority: 100
+
+# zram_packages: distro packages to install. zram-tools ships a deployable
+# /etc/default/zramswap config and a zramswap.service systemd unit.
+zram_packages:
+    - zram-tools
+
+# zram_kernel_module_package: Paket, das das zram-Kernel-Modul liefert.
+# Auf Hetzner-Cloud-Ubuntu mit linux-image-virtual ist das zram-Modul NICHT
+# im Standard-Image enthalten — es lebt in linux-modules-extra-<kernel-version>.
+# Die Variable wird zur Laufzeit gegen den aktuellen Kernel resolved (ansible_kernel),
+# sodass Kernel-Upgrades automatisch das passende neue Paket ziehen.
+# Siehe .kiro/specs/code-server-swap/research.md I6/D6.
+zram_kernel_module_package: "linux-modules-extra-{{ ansible_kernel }}"

--- a/roles/zram/handlers/main.yml
+++ b/roles/zram/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart zramswap
+  ansible.builtin.systemd:
+      name: zramswap
+      state: restarted
+  become: true

--- a/roles/zram/meta/argument_specs.yml
+++ b/roles/zram/meta/argument_specs.yml
@@ -48,9 +48,8 @@ argument_specs:
 
             zram_kernel_module_package:
                 description:
-                    - "Package that provides the zram kernel module"
-                    - "Resolved at runtime against the running kernel (ansible_kernel) so kernel upgrades pull the matching package"
-                    - "On Ubuntu cloud images with linux-image-virtual the zram module lives in linux-modules-extra-<kernel>"
+                    - "Package that provides the zram kernel module; empty value skips the install"
+                    - "On Ubuntu, resolved at runtime to linux-modules-extra-<kernel> so kernel upgrades pull the matching package"
+                    - "Empty on Debian, which ships the zram module in the stock kernel with no separate package"
                 type: "str"
                 required: false
-                default: "linux-modules-extra-{{ ansible_kernel }}"

--- a/roles/zram/meta/argument_specs.yml
+++ b/roles/zram/meta/argument_specs.yml
@@ -1,0 +1,56 @@
+---
+argument_specs:
+    main:
+        short_description: "Configure compressed RAM swap (zram) on Linux systems"
+        description:
+            - "Installs the zram-tools package and the kernel module that provides zram"
+            - "Validates the requested compression algorithm against kernel capabilities"
+            - "Deploys /etc/default/zramswap and enables the zramswap service"
+            - "Arillso"
+        options:
+            zram_enabled:
+                description: "Enable or disable the zram role; false makes every task a no-op"
+                type: "bool"
+                required: false
+                default: true
+
+            zram_percent:
+                description:
+                    - "Percentage of physical RAM to allocate as the zram swap device"
+                    - "50 means a 16 GB host gets an 8 GB zram device"
+                type: "int"
+                required: false
+                default: 50
+
+            zram_algorithm:
+                description:
+                    - "Kernel compression algorithm for the zram device"
+                    - "Validated at runtime against /sys/block/zram0/comp_algorithm"
+                type: "str"
+                required: false
+                default: "zstd"
+
+            zram_priority:
+                description:
+                    - "Linux swap priority for the zram device (higher wins)"
+                    - "Should be greater than any disk-based swap priority so the kernel fills zram first"
+                type: "int"
+                required: false
+                default: 100
+
+            zram_packages:
+                description: "Distribution packages to install that provide zram userspace tooling"
+                type: "list"
+                elements: "str"
+                required: false
+                default:
+                    - "zram-tools"
+
+            zram_kernel_module_package:
+                description:
+                    - "Package that provides the zram kernel module"
+                    - "Resolved at runtime against the running kernel (ansible_kernel) so kernel upgrades pull the matching package"
+                    - "On Ubuntu cloud images with linux-image-virtual the zram module lives in linux-modules-extra-<kernel>"
+                type: "str"
+                required: false
+                default: "linux-modules-extra-{{ ansible_kernel }}"

--- a/roles/zram/meta/main.yml
+++ b/roles/zram/meta/main.yml
@@ -1,0 +1,32 @@
+---
+# Role metadata for compressed RAM swap (zram)
+
+galaxy_info:
+    role_name: zram
+    namespace: arillso
+    author: sbaerlocher
+    description: >-
+        Compressed RAM swap (zram) backend via the Debian/Ubuntu zram-tools package.
+    license: MIT
+    min_ansible_version: "2.15"
+
+    platforms:
+        - name: Debian
+          versions:
+              - bookworm
+              - trixie
+        - name: Ubuntu
+          versions:
+              - jammy
+              - noble
+
+    galaxy_tags:
+        - swap
+        - zram
+        - memory
+        - system
+
+dependencies: []
+
+collections:
+    - community.general

--- a/roles/zram/tasks/bootstrap.yml
+++ b/roles/zram/tasks/bootstrap.yml
@@ -1,0 +1,15 @@
+---
+- name: Install kernel module package providing zram
+  ansible.builtin.include_role:
+      name: arillso.system.packages
+      tasks_from: packages
+  vars:
+      packages_list:
+          - name: "{{ zram_kernel_module_package }}"
+            state: present
+
+- name: Load zram kernel module
+  community.general.modprobe:
+      name: zram
+      state: present
+  become: true

--- a/roles/zram/tasks/bootstrap.yml
+++ b/roles/zram/tasks/bootstrap.yml
@@ -1,4 +1,16 @@
 ---
+- name: Cache update via packages role
+  ansible.builtin.include_role:
+      name: arillso.system.packages
+      tasks_from: cache
+  vars:
+      packages_update_cache: true
+      packages_cache_valid_time: 3600
+
+# Debian ships the zram module in the stock kernel (linux-image-*) and has no
+# linux-modules-extra-* package, so the install only runs where the resolved
+# package name is non-empty — i.e. on distributions that actually split the
+# module out (Ubuntu cloud images with linux-image-virtual).
 - name: Install kernel module package providing zram
   ansible.builtin.include_role:
       name: arillso.system.packages
@@ -7,9 +19,15 @@
       packages_list:
           - name: "{{ zram_kernel_module_package }}"
             state: present
+  when: zram_kernel_module_package | length > 0
 
+# num_devices=1 is the kernel default, but stating it explicitly guarantees
+# /sys/block/zram0 exists for the algorithm validation in validate.yml — a host
+# with `options zram num_devices=0` in /etc/modprobe.d/ would otherwise leave no
+# device node and fail the slurp with an opaque "file not found".
 - name: Load zram kernel module
   community.general.modprobe:
       name: zram
+      params: num_devices=1
       state: present
   become: true

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+- name: Bootstrap zram kernel module on host
+  ansible.builtin.include_tasks: bootstrap.yml
+  when: zram_enabled
+
+- name: Validate zram configuration against kernel capabilities
+  ansible.builtin.include_tasks: validate.yml
+  when: zram_enabled
+
+- name: Install zram tools package via packages role
+  ansible.builtin.include_role:
+      name: arillso.system.packages
+      tasks_from: packages
+  vars:
+      packages_list: >-
+          {{ zram_packages
+             | map('community.general.dict_kv', 'name')
+             | map('combine', {'state': 'present'})
+             | list }}
+  when: zram_enabled
+
+- name: Deploy zramswap configuration
+  ansible.builtin.template:
+      src: etc/default/zramswap.j2
+      dest: /etc/default/zramswap
+      owner: root
+      group: root
+      mode: "0644"
+  become: true
+  notify: Restart zramswap
+  when: zram_enabled
+
+- name: Manage zramswap service via systemd role
+  ansible.builtin.include_role:
+      name: arillso.system.systemd
+      tasks_from: service
+  vars:
+      systemd_services:
+          - name: zramswap
+            enabled: true
+            state: started
+            daemon_reload: true
+  when: zram_enabled

--- a/roles/zram/tasks/validate.yml
+++ b/roles/zram/tasks/validate.yml
@@ -1,0 +1,22 @@
+---
+- name: Slurp available zram compression algorithms from kernel
+  ansible.builtin.slurp:
+      src: /sys/block/zram0/comp_algorithm
+  register: zram_comp_algorithm_raw
+  changed_when: false
+
+- name: Parse available zram compression algorithms
+  ansible.builtin.set_fact:
+      zram_available_algorithms: >-
+          {{ (zram_comp_algorithm_raw.content | b64decode | trim).split()
+             | map('regex_replace', '^\[|\]$', '')
+             | list }}
+
+- name: Assert the requested zram algorithm is available in this kernel
+  ansible.builtin.assert:
+      that:
+          - zram_algorithm in zram_available_algorithms
+      fail_msg: >-
+          zram_algorithm '{{ zram_algorithm }}' is not available in this kernel.
+          Available algorithms: {{ zram_available_algorithms | join(', ') }}.
+          Choose one of the listed values or load the required compression module.

--- a/roles/zram/templates/etc/default/zramswap.j2
+++ b/roles/zram/templates/etc/default/zramswap.j2
@@ -1,0 +1,11 @@
+# Managed by Ansible role: zram
+# Source variables: zram_algorithm, zram_percent, zram_priority
+
+# Compression algorithm. Must be available in /sys/block/zram0/comp_algorithm.
+ALGO={{ zram_algorithm }}
+
+# Percentage of total RAM to allocate as zram swap.
+PERCENT={{ zram_percent }}
+
+# Linux swap priority (higher wins). zram should be > any disk swap priority.
+PRIORITY={{ zram_priority }}


### PR DESCRIPTION
## Summary

- New `zram` role: compressed RAM swap via the Debian/Ubuntu `zram-tools` package. Bootstraps the kernel module (incl. `linux-modules-extra-<kernel>` on cloud images), validates the compression algorithm against the running kernel, deploys `/etc/default/zramswap`, and manages the `zramswap` service via the `arillso.system.systemd` sub-role. Aligned to the collection standard: `zram_enabled` master toggle, `assert`-based validation, and least-privilege `become` (consistent with c73596b).
- `tuning` swap fixes: `fail`→`assert` (the old AND-joined guards never fired), header-overhead rounding so `current_swap_size` no longer triggers a recreate loop every run, removal of the multi-GB pre-resize backup (replaced with an explicit shrink refusal), and a `swap_file_active` refresh after `swapoff`.
- `tuning` swap priority: new `tuning_swap_priority` (default `0`, backward-compatible) via `swapon -p` and `pri=N` in fstab, enabling a zram-first layout with disk swap as a lower-priority fallback.

## Test plan

- [ ] MegaLinter / ansible-lint green (locally: 0 failures, production profile)
- [ ] Molecule scenario for `zram` to follow in a later PR