### PR TITLE
ci(renovate): track molecule images and python_version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["github>arillso/.github:renovate-ansible#2026-06-12"],
+    "extends": ["github>arillso/.github:renovate-ansible#2026-06-14"],
     "packageRules": [
         {
             "matchPackageNames": ["ansible-core"],
@@ -10,7 +10,10 @@
     "customManagers": [
         {
             "customType": "regex",
-            "managerFilePatterns": ["/^roles/.*/defaults/main\\.yml$/", "/^roles/.*/meta/argument_specs\\.yml$/"],
+            "managerFilePatterns": [
+                "/^roles/.*/defaults/main\\.yml$/",
+                "/^roles/.*/meta/argument_specs\\.yml$/"
+            ],
             "matchStrings": [
                 "#\\s*renovate:\\s*datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(?:\\s+extractVersion=(?<extractVersion>\\S+))?(?:\\s+versioning=(?<versioning>\\S+))?\\s*(?:\\r?\\n|\\r).*?:\\s*[\"']?(?<currentValue>[^\"'\\s]+)[\"']?\\s*(?:\\r?\\n|\\r|$)"
             ],

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -24,6 +24,7 @@ jobs:
         with:
             collection_namespace: arillso
             collection_name: system
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             enable_unit_tests: true
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,6 +26,7 @@ jobs:
         with:
             collection_namespace: arillso
             collection_name: system
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             enable_unit_tests: true
 
@@ -44,6 +45,7 @@ jobs:
         with:
             collection_namespace: arillso
             collection_name: system
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             concurrency-suffix: molecule
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validation, even on hosts that override the modprobe default.
 - `tuning` role: split the network sysctl loop into a required and an
   optional task, gated by `_net_sysctl_item.key in
-  tuning_optional_network_sysctl_params`. The previous single task
+tuning_optional_network_sysctl_params`. The previous single task
   self-referenced its own `register` result inside `failed_when`, which
   relies on subtle ansible-core semantics and was brittle to refactor.
   Optional sysctl misses are now reported via a follow-up debug task.
@@ -106,7 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `access`, `logging` and `network` roles, and two in the
   `packages` role — the included task already escalates), plus the
   `block`-level `become: true` in the `network` role (every task in
-  `resolv.yml`/`netplan.yml` escalates on its own). `apply:`/`block:` escalation applies `become` to *every*
+  `resolv.yml`/`netplan.yml` escalates on its own). `apply:`/`block:` escalation applies `become` to _every_
   task in scope; task-level escalation applies it only where it is
   needed. No functional change — the privileged tasks still run as root.
 - All roles: rework handlers into a `<role>: <action>` event-bus
@@ -134,6 +134,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   discovers scenarios from `extensions/molecule/`) and pin all four
   reusable workflows (ci, molecule, security-secrets, claude-review)
   to the same `2026-06-12` tag.
+- CI/Renovate: close the remaining version-tracking gaps. All 15
+  molecule platform images (`geerlingguy/docker-*-ansible`) are pinned
+  to `latest@sha256:...` with a `# renovate: datasource=docker` marker
+  so Renovate keeps the digests fresh (the images publish only a
+  `latest` tag, so digest pinning is the only way to track them), and
+  each `python_version` CI input carries a
+  `# renovate: datasource=github-releases depName=python/cpython`
+  marker. Bumps the `arillso/.github` Renovate preset pin to
+  `2026-06-14`, whose comment manager splits an `@sha256:...` suffix
+  into `currentDigest` (required for the molecule digest pins to update
+  cleanly).
 
 ## [1.1.6] - 2026-05-17
 
@@ -159,7 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `firewall` role: scope nftables flush to managed tables instead of running
   a global `flush ruleset`. Both the rendered `/etc/nftables.conf` and the
-  systemd-override `ExecStop` previously wiped *all* nftables state on each
+  systemd-override `ExecStop` previously wiped _all_ nftables state on each
   reload/restart, including tables managed by other sources (Docker's
   iptables-nft `ip nat` / `ip filter` chains, kube-proxy, manually added
   entries). Container recreates after a firewall handler run failed with
@@ -171,7 +182,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `access` role: only set `append` on the `ansible.builtin.user` module when
   `groups` is also defined for the entry. The previous unconditional
   `append` emitted the warning `'append' is set, but no 'groups' are
-  specified` and would have failed hard once that warning is promoted to an
+specified` and would have failed hard once that warning is promoted to an
   error in `ansible-core` 2.14
 - All `include_role` calls to the `systemd` role now pass `become: true`
   through `apply:` (in `access/ssh_server`, `logging/rsyslog`,

--- a/extensions/molecule/access/molecule.yml
+++ b/extensions/molecule/access/molecule.yml
@@ -9,7 +9,8 @@ driver:
 
 platforms:
     - name: access-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -23,7 +24,8 @@ platforms:
           - debian
 
     - name: access-ubuntu-noble
-      image: geerlingguy/docker-ubuntu2404-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
+      image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -37,7 +39,8 @@ platforms:
           - debian
 
     - name: access-rocky-9
-      image: geerlingguy/docker-rockylinux9-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
+      image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/ansible/molecule.yml
+++ b/extensions/molecule/ansible/molecule.yml
@@ -9,7 +9,8 @@ driver:
 
 platforms:
     - name: ansible-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -21,7 +22,8 @@ platforms:
           - /run/lock
 
     - name: ansible-ubuntu-noble
-      image: geerlingguy/docker-ubuntu2404-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
+      image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/bitwarden_secrets/molecule.yml
+++ b/extensions/molecule/bitwarden_secrets/molecule.yml
@@ -9,7 +9,8 @@ driver:
 
 platforms:
     - name: bws-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -21,7 +22,8 @@ platforms:
           - /run/lock
 
     - name: bws-rocky-9
-      image: geerlingguy/docker-rockylinux9-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
+      image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/facts/molecule.yml
+++ b/extensions/molecule/facts/molecule.yml
@@ -9,7 +9,8 @@ driver:
 
 platforms:
     - name: facts-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -21,7 +22,8 @@ platforms:
           - /run/lock
 
     - name: facts-ubuntu-noble
-      image: geerlingguy/docker-ubuntu2404-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
+      image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -33,7 +35,8 @@ platforms:
           - /run/lock
 
     - name: facts-rocky-9
-      image: geerlingguy/docker-rockylinux9-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
+      image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/firewall/molecule.yml
+++ b/extensions/molecule/firewall/molecule.yml
@@ -14,7 +14,8 @@ driver:
 
 platforms:
     - name: firewall-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/logging/molecule.yml
+++ b/extensions/molecule/logging/molecule.yml
@@ -9,7 +9,8 @@ driver:
 
 platforms:
     - name: logging-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -21,7 +22,8 @@ platforms:
           - /run/lock
 
     - name: logging-ubuntu-noble
-      image: geerlingguy/docker-ubuntu2404-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
+      image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -33,7 +35,8 @@ platforms:
           - /run/lock
 
     - name: logging-rocky-9
-      image: geerlingguy/docker-rockylinux9-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
+      image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/network/molecule.yml
+++ b/extensions/molecule/network/molecule.yml
@@ -12,7 +12,8 @@ driver:
 
 platforms:
     - name: network-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -24,7 +25,8 @@ platforms:
           - /run/lock
 
     - name: network-ubuntu-noble
-      image: geerlingguy/docker-ubuntu2404-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
+      image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/packages/molecule.yml
+++ b/extensions/molecule/packages/molecule.yml
@@ -9,7 +9,8 @@ driver:
 
 platforms:
     - name: packages-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -21,7 +22,8 @@ platforms:
           - /run/lock
 
     - name: packages-ubuntu-noble
-      image: geerlingguy/docker-ubuntu2404-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
+      image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/python/molecule.yml
+++ b/extensions/molecule/python/molecule.yml
@@ -9,7 +9,8 @@ driver:
 
 platforms:
     - name: python-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -21,7 +22,8 @@ platforms:
           - /run/lock
 
     - name: python-rocky-9
-      image: geerlingguy/docker-rockylinux9-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
+      image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/ready/molecule.yml
+++ b/extensions/molecule/ready/molecule.yml
@@ -9,7 +9,8 @@ driver:
 
 platforms:
     - name: ready-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/shell/molecule.yml
+++ b/extensions/molecule/shell/molecule.yml
@@ -9,7 +9,8 @@ driver:
 
 platforms:
     - name: shell-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -21,7 +22,8 @@ platforms:
           - /run/lock
 
     - name: shell-ubuntu-noble
-      image: geerlingguy/docker-ubuntu2404-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
+      image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -33,7 +35,8 @@ platforms:
           - /run/lock
 
     - name: shell-rocky-9
-      image: geerlingguy/docker-rockylinux9-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
+      image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/systemd/molecule.yml
+++ b/extensions/molecule/systemd/molecule.yml
@@ -9,7 +9,8 @@ driver:
 
 platforms:
     - name: systemd-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -21,7 +22,8 @@ platforms:
           - /run/lock
 
     - name: systemd-ubuntu-noble
-      image: geerlingguy/docker-ubuntu2404-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
+      image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true
@@ -33,7 +35,8 @@ platforms:
           - /run/lock
 
     - name: systemd-rocky-9
-      image: geerlingguy/docker-rockylinux9-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
+      image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/thermal/molecule.yml
+++ b/extensions/molecule/thermal/molecule.yml
@@ -12,7 +12,8 @@ driver:
 
 platforms:
     - name: thermal-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/tuning/molecule.yml
+++ b/extensions/molecule/tuning/molecule.yml
@@ -14,7 +14,8 @@ driver:
 
 platforms:
     - name: tuning-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true

--- a/extensions/molecule/zram/molecule.yml
+++ b/extensions/molecule/zram/molecule.yml
@@ -15,7 +15,8 @@ driver:
 
 platforms:
     - name: zram-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest
+      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
+      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
       pre_build_image: true


### PR DESCRIPTION
## Summary

- Close the remaining Renovate coverage gaps in this collection. All 15 molecule platform images (`geerlingguy/docker-*-ansible`) are pinned to `latest@sha256:...` with a `# renovate: datasource=docker` marker so the digests stay reproducible and Renovate keeps them fresh — these images publish only a `latest` tag, so digest pinning is the only way to track them.
- Each `python_version` CI input carries a `# renovate: datasource=github-releases depName=python/cpython` marker so the Python minor used by CI is tracked.
- Bump the `arillso/.github` Renovate preset pin to `2026-06-14`, whose comment manager splits an `@sha256:...` suffix into `currentDigest` — the upstream fix that lets the molecule digest pins above update cleanly instead of the whole image string being captured as `currentValue`.
- Document the change under `CHANGELOG [Unreleased]`.

## Test plan

- [x] `renovate-config-validator --strict` passes on `.github/renovate.json` with the bumped pin
- [x] markdownlint + prettier clean on `CHANGELOG.md` and `renovate.json`
- [ ] CI green (lint, unit, molecule, secret scan, claude review)
