### PR TITLE
fix(renovate): track molecule image digests via dedicated docker manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,15 +136,18 @@ tuning_optional_network_sysctl_params`. The previous single task
   to the same `2026-06-12` tag.
 - CI/Renovate: close the remaining version-tracking gaps. All 15
   molecule platform images (`geerlingguy/docker-*-ansible`) are pinned
-  to `latest@sha256:...` with a `# renovate: datasource=docker` marker
-  so Renovate keeps the digests fresh (the images publish only a
-  `latest` tag, so digest pinning is the only way to track them), and
-  each `python_version` CI input carries a
-  `# renovate: datasource=github-releases depName=python/cpython`
-  marker. Bumps the `arillso/.github` Renovate preset pin to
-  `2026-06-14`, whose comment manager splits an `@sha256:...` suffix
-  into `currentDigest` (required for the molecule digest pins to update
-  cleanly).
+  to `latest@sha256:...`. Tracking is handled by the shared
+  `renovate-ansible` preset, which now carries a dedicated `docker`
+  customManager for molecule `image:` lines (parses the line directly so
+  `currentValue` is the bare tag and `@sha256:...` is the digest — the
+  form Renovate's Docker datasource needs to refresh it) plus a
+  `pinDigests` rule; the preset pin is bumped to `2026-06-14`. The images
+  publish only a `latest` tag, so digest pinning is the only way to track
+  them. A local marker-comment approach was tried first but the generic
+  comment manager captured `repo:tag` as `currentValue`, which Renovate
+  could not resolve ("Could not determine new digest"); the preset-side
+  manager needs no markers. Each `python_version` CI input carries a
+  `# renovate: datasource=github-releases depName=python/cpython` marker.
 
 ## [1.1.6] - 2026-05-17
 

--- a/extensions/molecule/access/molecule.yml
+++ b/extensions/molecule/access/molecule.yml
@@ -9,7 +9,6 @@ driver:
 
 platforms:
     - name: access-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -24,7 +23,6 @@ platforms:
           - debian
 
     - name: access-ubuntu-noble
-      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
       image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -39,7 +37,6 @@ platforms:
           - debian
 
     - name: access-rocky-9
-      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
       image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/ansible/molecule.yml
+++ b/extensions/molecule/ansible/molecule.yml
@@ -9,7 +9,6 @@ driver:
 
 platforms:
     - name: ansible-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -22,7 +21,6 @@ platforms:
           - /run/lock
 
     - name: ansible-ubuntu-noble
-      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
       image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/bitwarden_secrets/molecule.yml
+++ b/extensions/molecule/bitwarden_secrets/molecule.yml
@@ -9,7 +9,6 @@ driver:
 
 platforms:
     - name: bws-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -22,7 +21,6 @@ platforms:
           - /run/lock
 
     - name: bws-rocky-9
-      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
       image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/facts/molecule.yml
+++ b/extensions/molecule/facts/molecule.yml
@@ -9,7 +9,6 @@ driver:
 
 platforms:
     - name: facts-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -22,7 +21,6 @@ platforms:
           - /run/lock
 
     - name: facts-ubuntu-noble
-      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
       image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -35,7 +33,6 @@ platforms:
           - /run/lock
 
     - name: facts-rocky-9
-      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
       image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/firewall/molecule.yml
+++ b/extensions/molecule/firewall/molecule.yml
@@ -14,7 +14,6 @@ driver:
 
 platforms:
     - name: firewall-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/logging/molecule.yml
+++ b/extensions/molecule/logging/molecule.yml
@@ -9,7 +9,6 @@ driver:
 
 platforms:
     - name: logging-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -22,7 +21,6 @@ platforms:
           - /run/lock
 
     - name: logging-ubuntu-noble
-      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
       image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -35,7 +33,6 @@ platforms:
           - /run/lock
 
     - name: logging-rocky-9
-      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
       image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/network/molecule.yml
+++ b/extensions/molecule/network/molecule.yml
@@ -12,7 +12,6 @@ driver:
 
 platforms:
     - name: network-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -25,7 +24,6 @@ platforms:
           - /run/lock
 
     - name: network-ubuntu-noble
-      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
       image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/packages/molecule.yml
+++ b/extensions/molecule/packages/molecule.yml
@@ -9,7 +9,6 @@ driver:
 
 platforms:
     - name: packages-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -22,7 +21,6 @@ platforms:
           - /run/lock
 
     - name: packages-ubuntu-noble
-      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
       image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/python/molecule.yml
+++ b/extensions/molecule/python/molecule.yml
@@ -9,7 +9,6 @@ driver:
 
 platforms:
     - name: python-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -22,7 +21,6 @@ platforms:
           - /run/lock
 
     - name: python-rocky-9
-      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
       image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/ready/molecule.yml
+++ b/extensions/molecule/ready/molecule.yml
@@ -9,7 +9,6 @@ driver:
 
 platforms:
     - name: ready-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/shell/molecule.yml
+++ b/extensions/molecule/shell/molecule.yml
@@ -9,7 +9,6 @@ driver:
 
 platforms:
     - name: shell-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -22,7 +21,6 @@ platforms:
           - /run/lock
 
     - name: shell-ubuntu-noble
-      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
       image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -35,7 +33,6 @@ platforms:
           - /run/lock
 
     - name: shell-rocky-9
-      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
       image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/systemd/molecule.yml
+++ b/extensions/molecule/systemd/molecule.yml
@@ -9,7 +9,6 @@ driver:
 
 platforms:
     - name: systemd-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -22,7 +21,6 @@ platforms:
           - /run/lock
 
     - name: systemd-ubuntu-noble
-      # renovate: datasource=docker depName=geerlingguy/docker-ubuntu2404-ansible
       image: geerlingguy/docker-ubuntu2404-ansible:latest@sha256:68af87df907605679a3fd572d0eb8b13330b160a3aa89fe9d89e31a4d8ef6ca0
       command: /usr/lib/systemd/systemd
       privileged: true
@@ -35,7 +33,6 @@ platforms:
           - /run/lock
 
     - name: systemd-rocky-9
-      # renovate: datasource=docker depName=geerlingguy/docker-rockylinux9-ansible
       image: geerlingguy/docker-rockylinux9-ansible:latest@sha256:967060db9f42dc650fddc74ea175f7aec0b0c852884645a10c95ddaea517eb10
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/thermal/molecule.yml
+++ b/extensions/molecule/thermal/molecule.yml
@@ -12,7 +12,6 @@ driver:
 
 platforms:
     - name: thermal-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/tuning/molecule.yml
+++ b/extensions/molecule/tuning/molecule.yml
@@ -14,7 +14,6 @@ driver:
 
 platforms:
     - name: tuning-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true

--- a/extensions/molecule/zram/molecule.yml
+++ b/extensions/molecule/zram/molecule.yml
@@ -15,7 +15,6 @@ driver:
 
 platforms:
     - name: zram-debian-bookworm
-      # renovate: datasource=docker depName=geerlingguy/docker-debian12-ansible
       image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
       command: /usr/lib/systemd/systemd
       privileged: true


### PR DESCRIPTION
## Summary

- The marker-comment approach from #153 made Renovate **detect** the molecule platform images but not **update** them: the generic comment customManager captured `currentValue = "<repo>:latest"` (repo and tag glued together) instead of the bare tag, so the Docker datasource could not resolve a new digest. The dependency dashboard (#78) reported `Could not determine new digest` for all three `geerlingguy/docker-*-ansible` images.
- Replace the marker comments with a dedicated `docker` customManager scoped to `extensions/molecule/**/molecule.yml` that parses the `image:` line directly: `depName` = repo, `currentValue` = bare tag (`latest`), `@sha256:...` = `currentDigest` — the exact shape Renovate's Docker datasource needs to refresh the digest.
- The native `docker-compose` manager was evaluated first, but `molecule.yml` is not a compose schema (`platforms:`, no `services:`), so it extracts nothing — confirmed via dry-run. The 30 marker comments are removed since the dedicated manager needs none.

## Test plan

- [x] `renovate --dry-run` (extract): `currentValue` is now `latest` (bare tag), 0 occurrences of the old `repo:tag` currentValue
- [x] `renovate --dry-run` (lookup): `getDigest(index.docker.io, geerlingguy/..., latest)` runs; `Could not determine new digest` error gone (0 occurrences)
- [x] `renovate-config-validator --strict` passes; markdownlint, prettier, yamllint clean
- [ ] CI green (lint, unit, molecule, secret scan)
