### PR TITLE
fix(system): harden release lookup and align role min_ansible_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **github_latest_release lookup**: the GitHub API request had no timeout and no
+  retry, so network flakiness or a transient `429`/`5xx` aborted the task. The
+  request now uses a 10s timeout and retries up to 3 times with a linear backoff
+  on `URLError`, socket timeouts, and retryable status codes (429/502/503/504);
+  non-retryable errors (e.g. `404`) still fail fast.
 - `tuning` role: replace the two swap-validation `fail` tasks with
   `assert`. The previous `when:` lists were AND-joined, but the
   conditions were mutually exclusive (a variable cannot be both
@@ -110,6 +115,14 @@ tuning_optional_network_sysctl_params`. The previous single task
   reusable workflow to `@2026-06-17`.
 - `.python-version` `3.14` → `3.13` (org-wide target — `3.14` is rejected by
   `ansible-test`, which supports at most `3.13`).
+- **Role metadata**: bump `min_ansible_version` to `"2.18"` across all 15 roles
+  to match the collection's `requires_ansible: ">=2.18.0"` (`meta/runtime.yml`).
+- **Molecule**: add an `idempotence` step to the `firewall` and `ready` default
+  scenarios (the only converge-capable scenarios) so a second converge must
+  report `changed=0`.
+- **Renovate**: add a `# renovate:` comment to `bitwarden_secrets_version` in
+  the argument spec (the regex manager already scans `meta/argument_specs.yml`),
+  so the `bws` CLI version is bumped in both `defaults/main.yml` and the spec.
 - All roles: consolidate privilege escalation on the principle of least
   privilege. `become` now lives on the single privileged task (the
   `ansible.builtin.systemd` task inside the shared `systemd` sub-role),

--- a/extensions/molecule/firewall/molecule.yml
+++ b/extensions/molecule/firewall/molecule.yml
@@ -60,5 +60,6 @@ scenario:
         - create
         - prepare
         - converge
+        - idempotence
         - verify
         - destroy

--- a/extensions/molecule/ready/molecule.yml
+++ b/extensions/molecule/ready/molecule.yml
@@ -54,5 +54,6 @@ scenario:
         - syntax
         - create
         - converge
+        - idempotence
         - verify
         - destroy

--- a/plugins/lookup/github_latest_release.py
+++ b/plugins/lookup/github_latest_release.py
@@ -60,7 +60,6 @@ RETURN = r"""
 # pylint: disable=import-error
 from json import JSONDecodeError, loads  # noqa: E402
 from re import compile as regex_compile  # noqa: E402
-from socket import timeout as socket_timeout  # noqa: E402
 from time import sleep  # noqa: E402
 from urllib.error import HTTPError, URLError  # noqa: E402
 
@@ -127,7 +126,7 @@ class LookupModule(LookupBase):  # pylint: disable=too-few-public-methods
                             f"{to_native(e)}"
                         ) from e
                     last_error = e
-                except (URLError, socket_timeout) as e:
+                except (URLError, TimeoutError) as e:
                     last_error = e
 
                 if attempt < MAX_ATTEMPTS:

--- a/plugins/lookup/github_latest_release.py
+++ b/plugins/lookup/github_latest_release.py
@@ -60,6 +60,9 @@ RETURN = r"""
 # pylint: disable=import-error
 from json import JSONDecodeError, loads  # noqa: E402
 from re import compile as regex_compile  # noqa: E402
+from socket import timeout as socket_timeout  # noqa: E402
+from time import sleep  # noqa: E402
+from urllib.error import HTTPError, URLError  # noqa: E402
 
 from ansible.errors import AnsibleError, AnsibleParserError  # noqa: E402
 from ansible.module_utils._text import to_native, to_text  # noqa: E402
@@ -68,6 +71,13 @@ from ansible.plugins.lookup import LookupBase  # noqa: E402
 from ansible.utils.display import Display  # noqa: E402
 
 display = Display()
+
+# Network resilience settings for the Github API request.
+REQUEST_TIMEOUT = 10
+MAX_ATTEMPTS = 3
+RETRY_BACKOFF = 2
+# HTTP status codes that are worth retrying (rate limiting / transient errors).
+RETRYABLE_STATUS_CODES = (429, 502, 503, 504)
 
 
 class LookupModule(LookupBase):  # pylint: disable=too-few-public-methods
@@ -97,11 +107,43 @@ class LookupModule(LookupBase):  # pylint: disable=too-few-public-methods
 
             display.debug(f"Github version lookup term: '{to_text(repo)}'")
 
+            url = f"https://api.github.com/repos/{repo}/releases/latest"
+            response = None
+            last_error = None
+
+            for attempt in range(1, MAX_ATTEMPTS + 1):
+                try:
+                    response = open_url(
+                        url,
+                        headers={"Accept": "application/vnd.github.v3+json"},
+                        timeout=REQUEST_TIMEOUT,
+                    )
+                    break
+                except HTTPError as e:
+                    # Only retry transient HTTP errors; other status codes fail fast.
+                    if e.code not in RETRYABLE_STATUS_CODES:
+                        raise AnsibleError(
+                            f"Error fetching release from Github API for {to_text(repo)}: "
+                            f"{to_native(e)}"
+                        ) from e
+                    last_error = e
+                except (URLError, socket_timeout) as e:
+                    last_error = e
+
+                if attempt < MAX_ATTEMPTS:
+                    backoff = RETRY_BACKOFF * attempt
+                    display.vvvv(
+                        f"Github version lookup for {repo} failed "
+                        f"(attempt {attempt}/{MAX_ATTEMPTS}), retrying in {backoff}s"
+                    )
+                    sleep(backoff)
+                else:
+                    raise AnsibleError(
+                        f"Error fetching release from Github API for {to_text(repo)} "
+                        f"after {MAX_ATTEMPTS} attempts: {to_native(last_error)}"
+                    ) from last_error
+
             try:
-                response = open_url(
-                    f"https://api.github.com/repos/{repo}/releases/latest",
-                    headers={"Accept": "application/vnd.github.v3+json"},
-                )
                 json_response = loads(response.read().decode("utf-8"))
 
                 version = json_response.get("tag_name")

--- a/roles/access/meta/main.yml
+++ b/roles/access/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
     description: Role for managing system access - users, groups, sudo and SSH
     author: "arillso (@arillso)"
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
     platforms:
         - name: Debian
           versions:

--- a/roles/ansible/meta/main.yml
+++ b/roles/ansible/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
     author: sbaerlocher
     description: Configure Ansible automation (ansible-pull or ansible-playbook) with systemd timer
     license: MIT
-    min_ansible_version: "2.14"
+    min_ansible_version: "2.18"
 
     platforms:
         - name: Debian

--- a/roles/bitwarden_secrets/meta/argument_specs.yml
+++ b/roles/bitwarden_secrets/meta/argument_specs.yml
@@ -9,6 +9,7 @@ argument_specs:
             bitwarden_secrets_version:
                 description: "Version of bws CLI to install"
                 type: str
+                # renovate: datasource=github-releases depName=bitwarden/sdk-sm
                 default: "1.0.0"
             bitwarden_secrets_install_path:
                 description: "Installation path for bws binary"

--- a/roles/bitwarden_secrets/meta/main.yml
+++ b/roles/bitwarden_secrets/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
     description: Role for installing Bitwarden Secrets Manager CLI (bws)
     author: "arillso (@arillso)"
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
     platforms:
         - name: Debian
           versions:

--- a/roles/facts/meta/main.yml
+++ b/roles/facts/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
     description: "Enterprise-grade system facts collection and MOTD generation for Linux systems"
     company: "arillso"
     license: "MIT"
-    min_ansible_version: "2.12"
+    min_ansible_version: "2.18"
 
     platforms:
         - name: Ubuntu

--- a/roles/firewall/meta/main.yml
+++ b/roles/firewall/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
     description: "YAML-driven nftables firewall management with hierarchical configuration merging"
     company: Enterprise Infrastructure
     license: MIT
-    min_ansible_version: "2.9"
+    min_ansible_version: "2.18"
 
     platforms:
         - name: Ubuntu

--- a/roles/logging/meta/main.yml
+++ b/roles/logging/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
     description: Role for managing logging - logrotate and rsyslog
     author: "arillso (@arillso)"
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
     platforms:
         - name: Debian
           versions:

--- a/roles/network/meta/main.yml
+++ b/roles/network/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
     description: Role for managing network configuration - DNS and netplan
     author: "arillso (@arillso)"
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
     platforms:
         - name: Debian
           versions:

--- a/roles/packages/meta/main.yml
+++ b/roles/packages/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
     description: "Enterprise-ready Ansible role for managing APT packages, repositories, and keys"
     author: "arillso (@arillso)"
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
     platforms:
         - name: Ubuntu
           versions:

--- a/roles/python/meta/main.yml
+++ b/roles/python/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
     description: Role for managing Python packages via pip
     author: "arillso (@arillso)"
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
     platforms:
         - name: Debian
           versions:

--- a/roles/ready/meta/main.yml
+++ b/roles/ready/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
     description: "Wait for system readiness (cloud-init, SSH) before configuration"
     company: "arillso"
     license: "MIT"
-    min_ansible_version: "2.12"
+    min_ansible_version: "2.18"
 
     platforms:
         - name: Ubuntu

--- a/roles/shell/meta/main.yml
+++ b/roles/shell/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
     description: "Shell environment and MOTD configuration for Linux systems"
     company: "arillso"
     license: "MIT"
-    min_ansible_version: "2.12"
+    min_ansible_version: "2.18"
 
     platforms:
         - name: Ubuntu

--- a/roles/systemd/meta/main.yml
+++ b/roles/systemd/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
     description: Role for managing systemd services, units and journald
     author: "arillso (@arillso)"
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
     platforms:
         - name: Debian
           versions:

--- a/roles/thermal/meta/main.yml
+++ b/roles/thermal/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
     author: sbaerlocher
     description: Thermal management and fan control using thermald
     license: MIT
-    min_ansible_version: "2.9"
+    min_ansible_version: "2.18"
 
     platforms:
         - name: Ubuntu

--- a/roles/tuning/meta/main.yml
+++ b/roles/tuning/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
     description: Comprehensive system tuning for performance optimization using native Ansible modules
     company: "arillso"
     license: MIT
-    min_ansible_version: "2.9"
+    min_ansible_version: "2.18"
     platforms:
         - name: Ubuntu
           versions:

--- a/roles/zram/meta/main.yml
+++ b/roles/zram/meta/main.yml
@@ -8,7 +8,7 @@ galaxy_info:
     description: >-
         Compressed RAM swap (zram) backend via the Debian/Ubuntu zram-tools package.
     license: MIT
-    min_ansible_version: "2.15"
+    min_ansible_version: "2.18"
 
     platforms:
         - name: Debian


### PR DESCRIPTION
## Summary

- `github_latest_release` lookup: add 10s timeout + 3-attempt retry with linear backoff on URLError/socket-timeout/429/5xx; non-retryable errors (404) fail fast
- Bump `min_ansible_version` to `"2.18"` across all 15 roles to match `requires_ansible ">=2.18.0"`
- Add `idempotence` step to firewall + ready molecule scenarios (the only converge-capable ones)

Resolves audited Notion tickets for the system collection.

## Test plan

- [ ] CI green (lint + unit + molecule)
- [x] `ansible-lint roles/` → 0 failures, production profile
- [x] `py_compile plugins/lookup/github_latest_release.py` OK