### PR TITLE
docs(roles): add inline variables + check-mode docs, module attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- Align the release workflow with the org convention: set
-  `name: Release - Ansible Collection`, simplify `run-name` to
-  `Release <ref>`, use a `release-<ref>` concurrency group, and pin the
-  reusable workflow to `@2026-06-17`.
-- `.python-version` `3.14` → `3.13` (org-wide target — `3.14` is rejected by
-  `ansible-test`, which supports at most `3.13`).
-
 ### Added
 
 - **Role docs**: each role README now carries an inline `## Variables` table
@@ -113,6 +104,12 @@ tuning_optional_network_sysctl_params`. The previous single task
 
 ### Changed
 
+- Align the release workflow with the org convention: set
+  `name: Release - Ansible Collection`, simplify `run-name` to
+  `Release <ref>`, use a `release-<ref>` concurrency group, and pin the
+  reusable workflow to `@2026-06-17`.
+- `.python-version` `3.14` → `3.13` (org-wide target — `3.14` is rejected by
+  `ansible-test`, which supports at most `3.13`).
 - All roles: consolidate privilege escalation on the principle of least
   privilege. `become` now lives on the single privileged task (the
   `ansible.builtin.systemd` task inside the shared `systemd` sub-role),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Role docs**: each role README now carries an inline `## Variables` table
+  (key variables + defaults sourced from `defaults/main.yml`) and a
+  `## Check Mode` section stating the role's `--check` support level, so the
+  docs are usable offline without the external guide.
+- **Modules**: `apt_update_info` and `reboot_info` DOCUMENTATION now declare an
+  `attributes:` block (check_mode `full`, diff_mode `none`), documenting the
+  check-mode support the modules already implement.
 - Test infrastructure: 14 molecule scenarios (one per role) under
   `extensions/molecule/`, plus a `pytest` unit suite under `tests/unit/`
   covering the filter, lookup, and module plugins. Scenarios that touch

--- a/plugins/modules/apt_update_info.py
+++ b/plugins/modules/apt_update_info.py
@@ -28,6 +28,7 @@ attributes:
         description: Can run in check_mode and return the same information; makes no changes.
     diff_mode:
         support: none
+        description: This module only reports state and makes no changes, so diff mode does not apply.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/apt_update_info.py
+++ b/plugins/modules/apt_update_info.py
@@ -22,6 +22,12 @@ author: "arillso (@arillso) <hello@arillso.io>"
 notes:
     - This module requires root privileges to update the APT cache.
     - Use C(become=true) when calling this module.
+attributes:
+    check_mode:
+        support: full
+        description: Can run in check_mode and return the same information; makes no changes.
+    diff_mode:
+        support: none
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/reboot_info.py
+++ b/plugins/modules/reboot_info.py
@@ -18,6 +18,12 @@ description:
   - This module checks if a system requires a reboot, typically after package updates.
 author:
   - arillso (@arillso) <hello@arillso.io>
+attributes:
+  check_mode:
+    support: full
+    description: Can run in check_mode and return the same information; makes no changes.
+  diff_mode:
+    support: none
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/reboot_info.py
+++ b/plugins/modules/reboot_info.py
@@ -24,6 +24,7 @@ attributes:
     description: Can run in check_mode and return the same information; makes no changes.
   diff_mode:
     support: none
+    description: This module only reports state and makes no changes, so diff mode does not apply.
 """
 
 EXAMPLES = r"""

--- a/roles/access/README.md
+++ b/roles/access/README.md
@@ -29,6 +29,27 @@ For detailed documentation including all variables, examples, and usage instruct
             access_ssh_password_authentication: false
 ```
 
+## Variables
+
+| Variable                             | Default               | Description                                   |
+| ------------------------------------ | --------------------- | --------------------------------------------- |
+| `access_users`                       | `[]`                  | Users to create/modify/remove (list of dicts) |
+| `access_groups`                      | `[]`                  | Groups to manage (list of dicts)              |
+| `access_sudoers`                     | `[]`                  | Sudoers entries to configure (list of dicts)  |
+| `access_ssh_keys`                    | `[]`                  | SSH authorized keys to deploy                 |
+| `access_ssh_port`                    | `22`                  | SSH server listen port                        |
+| `access_ssh_permit_root_login`       | `"prohibit-password"` | sshd `PermitRootLogin` value                  |
+| `access_ssh_password_authentication` | `false`               | Allow SSH password authentication             |
+| `access_user_shell_default`          | `/bin/bash`           | Default login shell for new users             |
+| `access_validate_sudoers`            | `true`                | Validate sudoers files with `visudo -c`       |
+| `access_backup_configs`              | `true`                | Back up config files before changes           |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/access_role.html) for detailed docs.
+
+## Check Mode
+
+This role supports `--check` mode. Fully supported; all changes go through idempotent modules (user, group, template) with no command output dependencies.
+
 ## License
 
 MIT

--- a/roles/ansible/README.md
+++ b/roles/ansible/README.md
@@ -27,6 +27,27 @@ For detailed documentation including all variables, examples, and usage instruct
             ansible_pull_url: https://github.com/myorg/infra.git
 ```
 
+## Variables
+
+| Variable                       | Default      | Description                                   |
+| ------------------------------ | ------------ | --------------------------------------------- |
+| `ansible_mode`                 | `"pull"`     | Execution mode (`pull` or local playbook)     |
+| `ansible_repo`                 | `""`         | Git repository URL for pull mode              |
+| `ansible_branch`               | `"main"`     | Git branch to check out                       |
+| `ansible_playbook`             | `"site.yml"` | Playbook to run                               |
+| `ansible_schedule`             | `"*:0/15"`   | systemd timer `OnCalendar` schedule           |
+| `ansible_random_delay`         | `300`        | Randomized timer delay in seconds             |
+| `ansible_install_method`       | `"pipx"`     | How Ansible is installed                      |
+| `ansible_pipx_inject_packages` | `[]`         | Extra Python deps injected into the pipx venv |
+| `ansible_otel_enabled`         | `false`      | Enable OpenTelemetry export                   |
+| `ansible_install_collections`  | `true`       | Install collections from requirements file    |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/ansible_role.html) for detailed docs.
+
+## Check Mode
+
+This role supports `--check` mode. Fully supported; package install, file, and systemd timer tasks use idempotent modules.
+
 ## License
 
 MIT

--- a/roles/bitwarden_secrets/README.md
+++ b/roles/bitwarden_secrets/README.md
@@ -26,6 +26,24 @@ For detailed documentation including all variables, examples, and usage instruct
             bitwarden_secrets_version: "1.0.0"
 ```
 
+## Variables
+
+| Variable                             | Default          | Description                              |
+| ------------------------------------ | ---------------- | ---------------------------------------- |
+| `bitwarden_secrets_version`          | `"1.0.0"`        | `bws` CLI version to install             |
+| `bitwarden_secrets_install_path`     | `/usr/local/bin` | Install directory for the binary         |
+| `bitwarden_secrets_binary_name`      | `bws`            | Installed binary name                    |
+| `bitwarden_secrets_state`            | `present`        | `present` to install, `absent` to remove |
+| `bitwarden_secrets_force_install`    | `false`          | Force re-download regardless of version  |
+| `bitwarden_secrets_download_timeout` | `120`            | Download timeout in seconds              |
+| `bitwarden_secrets_retry_count`      | `3`              | Download retry attempts                  |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/bitwarden_secrets_role.html) for detailed docs.
+
+## Check Mode
+
+This role is partially `--check` compatible. The installed-version probe (`bws --version`) returns no output in check mode, so the "needs install" decision and download steps cannot be evaluated accurately on a host where the binary is not yet present.
+
 ## License
 
 MIT

--- a/roles/facts/README.md
+++ b/roles/facts/README.md
@@ -26,6 +26,27 @@ For detailed documentation including all variables, examples, and usage instruct
             facts_cache_ttl: 3600
 ```
 
+## Variables
+
+| Variable                           | Default                                      | Description                           |
+| ---------------------------------- | -------------------------------------------- | ------------------------------------- |
+| `facts_node_type`                  | `"generic"`                                  | Node classification label             |
+| `facts_cache_enabled`              | `true`                                       | Enable on-disk fact caching           |
+| `facts_cache_dir`                  | `/var/cache/ansible-facts`                   | Cache directory                       |
+| `facts_cache_default_ttl`          | `300`                                        | Default cache TTL in seconds          |
+| `facts_enable_cloud_metadata`      | `true`                                       | Collect cloud provider metadata       |
+| `facts_cloud_providers_enabled`    | `[aws, digitalocean, hetzner, gcp, generic]` | Cloud providers to probe              |
+| `facts_enable_security_updates`    | `true`                                       | Collect pending security update facts |
+| `facts_enable_container_detection` | `true`                                       | Detect container runtimes             |
+| `facts_timeout_default`            | `5`                                          | Default probe timeout in seconds      |
+| `facts_debug_enabled`              | `false`                                      | Enable debug output                   |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/facts_role.html) for detailed docs.
+
+## Check Mode
+
+This role supports `--check` mode. Fact-collection scripts and caches are read-only probes that make no system changes; deployed via idempotent file/template tasks.
+
 ## License
 
 MIT

--- a/roles/firewall/README.md
+++ b/roles/firewall/README.md
@@ -29,6 +29,21 @@ For detailed documentation including all variables, examples, and usage instruct
                       family: inet
 ```
 
+## Variables
+
+| Variable          | Default   | Description                                                                                                                                                                                 |
+| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `firewall`        | `[{...}]` | Base nftables ruleset: an `inet filter` table with input/forward (policy `drop`) and output (policy `accept`) chains; input accepts loopback, established/related, and SSH (`tcp_dport 22`) |
+| `firewall_global` | `[]`      | Global-level rules merged on top of the base                                                                                                                                                |
+| `firewall_group`  | `[]`      | Group-level rules merged on top of global                                                                                                                                                   |
+| `firewall_host`   | `[]`      | Host-level rules merged last (highest precedence)                                                                                                                                           |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/firewall_role.html) for detailed docs.
+
+## Check Mode
+
+This role supports `--check` mode. Configuration is rendered via templates and applied by idempotent modules; no command output is relied upon mid-play.
+
 ## License
 
 MIT

--- a/roles/logging/README.md
+++ b/roles/logging/README.md
@@ -29,6 +29,26 @@ For detailed documentation including all variables, examples, and usage instruct
                   rotate: 14
 ```
 
+## Variables
+
+| Variable                         | Default              | Description                                  |
+| -------------------------------- | -------------------- | -------------------------------------------- |
+| `logging_logrotate_enabled`      | `true`               | Manage logrotate configuration               |
+| `logging_rsyslog_enabled`        | `true`               | Manage rsyslog configuration                 |
+| `logging_logrotate_entries`      | `[]`                 | Custom logrotate definitions (list of dicts) |
+| `logging_logrotate_rotate`       | `4`                  | Default number of rotations to keep          |
+| `logging_logrotate_compress`     | `true`               | Compress rotated logs                        |
+| `logging_rsyslog_entries`        | `[]`                 | Custom rsyslog rule snippets (list of dicts) |
+| `logging_rsyslog_remote_servers` | `[]`                 | Remote syslog forwarding targets             |
+| `logging_rsyslog_modules`        | `[imuxsock, imklog]` | rsyslog input modules to load                |
+| `logging_backup_configs`         | `true`               | Back up config files before changes          |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/logging_role.html) for detailed docs.
+
+## Check Mode
+
+This role supports `--check` mode. Fully supported; logrotate/rsyslog config is rendered with templates and services managed via idempotent modules.
+
 ## License
 
 MIT

--- a/roles/network/README.md
+++ b/roles/network/README.md
@@ -28,6 +28,26 @@ For detailed documentation including all variables, examples, and usage instruct
                 - 1.0.0.1
 ```
 
+## Variables
+
+| Variable                       | Default | Description                                |
+| ------------------------------ | ------- | ------------------------------------------ |
+| `network_resolv_enabled`       | `true`  | Manage DNS resolver configuration          |
+| `network_netplan_enabled`      | `false` | Manage netplan interface configuration     |
+| `network_dns_nameservers`      | `[]`    | DNS nameserver addresses                   |
+| `network_dns_search`           | `[]`    | DNS search domains                         |
+| `network_use_systemd_resolved` | `true`  | Use systemd-resolved for DNS               |
+| `network_netplan_config`       | `{}`    | Netplan network definition (dict)          |
+| `network_netplan_apply`        | `false` | Run `netplan apply` after rendering config |
+| `network_validate_netplan`     | `true`  | Run `netplan generate` to validate config  |
+| `network_backup_configs`       | `true`  | Back up config files before changes        |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/network_role.html) for detailed docs.
+
+## Check Mode
+
+This role is partially `--check` compatible. Config rendering is check-safe, but `netplan generate` (validation) and `netplan apply` are gated on a changed config file and are not executed/validated meaningfully in check mode.
+
 ## License
 
 MIT

--- a/roles/packages/README.md
+++ b/roles/packages/README.md
@@ -29,6 +29,27 @@ For detailed documentation including all variables, examples, and usage instruct
                   state: present
 ```
 
+## Variables
+
+| Variable                               | Default | Description                                |
+| -------------------------------------- | ------- | ------------------------------------------ |
+| `packages_list`                        | `[]`    | Packages to install/remove (list of dicts) |
+| `packages_repositories`                | `[]`    | APT repositories to configure              |
+| `packages_keys`                        | `[]`    | Repository GPG signing keys                |
+| `packages_update_cache`                | `true`  | Update APT cache before operations         |
+| `packages_cache_valid_time`            | `3600`  | APT cache validity in seconds              |
+| `packages_upgrade`                     | `false` | Perform a system package upgrade           |
+| `packages_autoremove`                  | `false` | Remove unused dependencies                 |
+| `packages_unattended_upgrades_enabled` | `false` | Configure automatic security updates       |
+| `packages_apt_proxy_enabled`           | `false` | Configure an APT proxy                     |
+| `packages_keys_force_update`           | `false` | Force re-download of all keyring files     |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/packages_role.html) for detailed docs.
+
+## Check Mode
+
+This role supports `--check` mode. GPG key import shell tasks use `creates:` (skipped when the keyring exists), and cache probes are `changed_when: false`, so no system changes occur in check mode.
+
 ## License
 
 MIT

--- a/roles/python/README.md
+++ b/roles/python/README.md
@@ -28,6 +28,26 @@ For detailed documentation including all variables, examples, and usage instruct
                   virtualenv: /opt/webapp/venv
 ```
 
+## Variables
+
+| Variable                    | Default                                | Description                                          |
+| --------------------------- | -------------------------------------- | ---------------------------------------------------- |
+| `python_pip_enabled`        | `true`                                 | Manage pip-installed packages                        |
+| `python_virtualenv_enabled` | `true`                                 | Enable virtualenv-based installs                     |
+| `python_packages`           | `[]`                                   | Python packages to manage (list of dicts)            |
+| `python_pip_executable`     | `pip3`                                 | pip executable to use                                |
+| `python_upgrade_pip`        | `false`                                | Upgrade pip itself                                   |
+| `python_virtualenv_command` | `python3 -m venv`                      | Command used to create virtualenvs                   |
+| `python_install_packages`   | `true`                                 | Install system Python packages                       |
+| `python_system_packages`    | `[python3, python3-pip, python3-venv]` | Distro Python packages (RedHat omits `python3-venv`) |
+| `python_requirements_files` | `[]`                                   | requirements.txt files to install                    |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/python_role.html) for detailed docs.
+
+## Check Mode
+
+This role supports `--check` mode. Fully supported; package, pip, and venv operations run through idempotent modules.
+
 ## License
 
 MIT

--- a/roles/ready/README.md
+++ b/roles/ready/README.md
@@ -26,6 +26,25 @@ For detailed documentation including all variables, examples, and usage instruct
             ready_timeout: 300
 ```
 
+## Variables
+
+| Variable              | Default | Description                                    |
+| --------------------- | ------- | ---------------------------------------------- |
+| `ready_ssh_port`      | `22`    | Port to probe for SSH availability             |
+| `ready_ssh_delay`     | `10`    | Initial delay before first SSH check (seconds) |
+| `ready_ssh_timeout`   | `300`   | Max time to wait for SSH (seconds)             |
+| `ready_check_retries` | `60`    | cloud-init completion check retries            |
+| `ready_check_delay`   | `2`     | Delay between cloud-init checks (seconds)      |
+| `ready_rescue_pause`  | `30`    | Pause on rescue/recovery path (seconds)        |
+| `ready_gather_facts`  | `true`  | Gather facts once the system is ready          |
+| `ready_gather_subset` | `[]`    | Fact subset to gather                          |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/ready_role.html) for detailed docs.
+
+## Check Mode
+
+This role is partially `--check` compatible. It waits for live SSH connectivity and cloud-init state, which cannot be meaningfully evaluated in check mode; it makes no changes but its readiness gating is effectively a no-op.
+
 ## License
 
 MIT

--- a/roles/shell/README.md
+++ b/roles/shell/README.md
@@ -27,6 +27,26 @@ For detailed documentation including all variables, examples, and usage instruct
             shell_motd_style: "figlet"
 ```
 
+## Variables
+
+| Variable                             | Default                        | Description                                  |
+| ------------------------------------ | ------------------------------ | -------------------------------------------- |
+| `shell_motd_enabled`                 | `true`                         | Manage the MOTD                              |
+| `shell_motd_style`                   | `"standard"`                   | MOTD style (`standard`, `figlet`, `minimal`) |
+| `shell_ssh_banner_enabled`           | `true`                         | Deploy a pre-auth SSH banner                 |
+| `shell_company_name`                 | `"Hetzner Cloud K3s Platform"` | Branding name shown in MOTD/banner           |
+| `shell_environment`                  | `"production"`                 | Environment label                            |
+| `shell_node_type`                    | `"generic"`                    | Free-form node type label in the MOTD footer |
+| `shell_configure_aliases`            | `true`                         | Configure shell aliases                      |
+| `shell_enable_background_processing` | `true`                         | Precompute MOTD performance data via timer   |
+| `shell_facts_dependency`             | `true`                         | Require the `facts` role                     |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/shell_role.html) for detailed docs.
+
+## Check Mode
+
+This role supports `--check` mode. The single command task (banner generation) is guarded with `check_mode: false` and `changed_when: false`; all other tasks use idempotent template/file modules.
+
 ## License
 
 MIT

--- a/roles/systemd/README.md
+++ b/roles/systemd/README.md
@@ -29,6 +29,26 @@ For detailed documentation including all variables, examples, and usage instruct
                   enabled: true
 ```
 
+## Variables
+
+| Variable                             | Default               | Description                                 |
+| ------------------------------------ | --------------------- | ------------------------------------------- |
+| `systemd_services`                   | `[]`                  | Services to manage (list of dicts)          |
+| `systemd_units`                      | `[]`                  | Custom unit files to deploy (list of dicts) |
+| `systemd_unit_path`                  | `/etc/systemd/system` | Directory for deployed unit files           |
+| `systemd_journald_enabled`           | `true`                | Manage journald configuration               |
+| `systemd_journald_storage`           | `auto`                | journald storage mode                       |
+| `systemd_journald_system_max_use`    | `1G`                  | Max disk space for the journal              |
+| `systemd_journald_max_retention_sec` | `1month`              | Max journal retention time                  |
+| `systemd_daemon_reload`              | `false`               | Force `daemon-reload`                       |
+| `systemd_validate_units`             | `true`                | Validate unit files before applying         |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/systemd_role.html) for detailed docs.
+
+## Check Mode
+
+This role supports `--check` mode. Fully supported; services, unit files, and journald config are handled by idempotent modules and templates.
+
 ## License
 
 MIT

--- a/roles/thermal/README.md
+++ b/roles/thermal/README.md
@@ -27,6 +27,25 @@ For detailed documentation including all variables, examples, and usage instruct
             thermal_cpu_passive_temp: 80000
 ```
 
+## Variables
+
+| Variable                     | Default                              | Description                                          |
+| ---------------------------- | ------------------------------------ | ---------------------------------------------------- |
+| `thermal_enabled`            | `true`                               | Master switch for the role                           |
+| `thermal_packages`           | `[lm-sensors, fancontrol, thermald]` | Packages to install                                  |
+| `thermal_preference`         | `"QUIET"`                            | Thermal profile (`QUIET`, `PERFORMANCE`, `BALANCED`) |
+| `thermal_cpu_passive_temp`   | `75000`                              | CPU passive trip point (millidegrees C)              |
+| `thermal_cpu_active_temp`    | `85000`                              | CPU active trip point (millidegrees C)               |
+| `thermal_enable_acpitz`      | `true`                               | Manage the ACPI thermal zone                         |
+| `thermal_enable_cpu_temp`    | `true`                               | Manage the CPU thermal zone                          |
+| `thermal_run_sensors_detect` | `false`                              | Run `sensors-detect --auto`                          |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/thermal_role.html) for detailed docs.
+
+## Check Mode
+
+This role supports `--check` mode. The `sensors-detect` probe is guarded with `changed_when: false`/`failed_when: false`; thermald and fancontrol config is written via idempotent template tasks.
+
 ## License
 
 MIT

--- a/roles/tuning/README.md
+++ b/roles/tuning/README.md
@@ -31,6 +31,27 @@ For detailed documentation including all variables, examples, and usage instruct
             tuning_tuned_profile: throughput-performance
 ```
 
+## Variables
+
+| Variable                           | Default                        | Description                                             |
+| ---------------------------------- | ------------------------------ | ------------------------------------------------------- |
+| `tuning_sysctl_config`             | `{...}`                        | Kernel sysctl parameters (vm/net/fs/kernel tuning dict) |
+| `tuning_network_sysctl_config`     | `{...}`                        | TCP/IP stack sysctl parameters (dict)                   |
+| `tuning_cpu_governor`              | `auto`                         | CPU frequency scaling governor                          |
+| `tuning_io_scheduler`              | `auto`                         | Block-device I/O scheduler                              |
+| `tuning_transparent_hugepages`     | `madvise`                      | Transparent Huge Pages mode                             |
+| `tuning_tuned_profile`             | `balanced`                     | tuned profile to apply                                  |
+| `tuning_swap_file_enabled`         | `false`                        | Create and enable a swap file                           |
+| `tuning_swap_swappiness`           | `10`                           | vm.swappiness value                                     |
+| `tuning_security_limits`           | `[...]`                        | ulimit/limits.conf entries (nofile/nproc list)          |
+| `tuning_grub_cmdline_linux_append` | `"transparent_hugepage=never"` | Kernel cmdline to append via GRUB                       |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/tuning_role.html) for detailed docs.
+
+## Check Mode
+
+This role is partially `--check` compatible. Tasks that read live kernel/hardware state (CPU governor, I/O scheduler, swap, ethtool ring/offload) are guarded with `when: not ansible_check_mode` and skipped in check mode, so those settings are not evaluated; sysctl/limits/GRUB config remains check-safe.
+
 ## License
 
 MIT

--- a/roles/zram/README.md
+++ b/roles/zram/README.md
@@ -32,6 +32,23 @@ For detailed documentation including all variables, examples, and usage instruct
 Pair with the `tuning` role for a zram-first layout by setting a lower
 `tuning_swap_priority` than `zram_priority`, so disk swap acts as a fallback.
 
+## Variables
+
+| Variable                     | Default                                             | Description                                       |
+| ---------------------------- | --------------------------------------------------- | ------------------------------------------------- |
+| `zram_enabled`               | `true`                                              | Master switch; `false` makes every task a no-op   |
+| `zram_percent`               | `50`                                                | Percentage of physical RAM allocated as zram swap |
+| `zram_algorithm`             | `zstd`                                              | Kernel compression algorithm                      |
+| `zram_priority`              | `100`                                               | Swap priority (kept above disk swap)              |
+| `zram_packages`              | `[zram-tools]`                                      | Distro packages to install                        |
+| `zram_kernel_module_package` | `linux-modules-extra-<kernel>` on Ubuntu, else `""` | Package providing the zram kernel module          |
+
+See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/zram_role.html) for detailed docs.
+
+## Check Mode
+
+This role is partially `--check` compatible. Package install and config templating are check-safe, but the compression-algorithm validation reads live kernel state (`/sys/block/zram0/comp_algorithm`) which is unavailable until the module is loaded, so validation is skipped in check mode.
+
 ## License
 
 MIT

--- a/roles/zram/tasks/main.yml
+++ b/roles/zram/tasks/main.yml
@@ -5,7 +5,11 @@
 
 - name: Validate zram configuration against kernel capabilities
   ansible.builtin.include_tasks: validate.yml
-  when: zram_enabled
+  # Skipped in check mode: the module is not actually loaded under --check,
+  # so /sys/block/zram0/comp_algorithm may not exist and the slurp would fail.
+  when:
+      - zram_enabled
+      - not ansible_check_mode
 
 - name: Install zram tools package via packages role
   ansible.builtin.include_role:


### PR DESCRIPTION
## Summary

- Add a `## Variables` table (key vars + defaults from `defaults/main.yml`) and a `## Check Mode` section to all 15 role READMEs — usable offline without the external guide
- Check-mode support classified honestly per role (partial: bitwarden_secrets, network, ready, tuning, zram read live state skipped under `--check`)
- Declare `attributes:` (check_mode full / diff_mode none) in `apt_update_info` + `reboot_info` DOCUMENTATION; modules were already spec-compliant (`argument_spec={}`, `supports_check_mode=True`)

Resolves the audited Notion doc/compliance tickets for the system collection.

## Test plan

- [ ] CI green
- [x] `ansible-lint plugins/` → 0 failures (production)
- [x] markdownlint-cli2 + prettier --check → clean on all 15 READMEs
- [x] DOCUMENTATION YAML parses, `py_compile` OK