### PR TITLE
test(molecule): converge zram and tuning on KVM instead of syntax-only

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -31,9 +31,13 @@ jobs:
             enable_unit_tests: true
 
     molecule:
-        # Scenarios are auto-discovered from extensions/molecule/ by the
-        # reusable workflow (every subdir not starting with `.`). To pin
-        # the matrix explicitly, pass scenarios: '["access", ...]'.
+        # Docker-driver scenarios (syntax/lint or real container converge).
+        # The matrix is PINNED explicitly rather than auto-discovered so the
+        # kernel-bound scenarios that need a real kernel (zram, tuning) can run
+        # under the qemu driver in their own jobs below — a single
+        # docker-driver job does NOT install QEMU/KVM, so a qemu scenario in it
+        # would fail. thermal stays here (docker, syntax-only): a cloud KVM
+        # guest has no real thermal sensors, so a converge would be low-value.
         #
         # concurrency-suffix avoids a deadlock with the caller's
         # concurrency: group: ${{ github.workflow }}-${{ github.ref }} —
@@ -47,7 +51,40 @@ jobs:
             collection_name: system
             # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
+            scenarios: >-
+                ["access", "ansible", "bitwarden_secrets", "facts",
+                 "firewall", "logging", "network", "packages", "python",
+                 "ready", "shell", "systemd", "thermal"]
             concurrency-suffix: molecule
+
+    molecule-zram:
+        # zram needs a real kernel (loads the zram module, brings a zram swap
+        # device online), so it runs under the qemu (KVM) molecule driver,
+        # which the reusable provisions only when driver: qemu. Scenarios live
+        # under extensions/molecule/, so scenarios_root keeps the reusable's
+        # default and the matrix is pinned to the single zram scenario.
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-18
+        with:
+            collection_namespace: arillso
+            collection_name: system
+            driver: qemu
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
+            python_version: "3.12"
+            scenarios: '["zram"]'
+            concurrency-suffix: molecule-zram
+
+    molecule-tuning:
+        # tuning needs a real kernel (writable /proc/sys, swap file, THP), so
+        # it runs under the qemu (KVM) molecule driver like zram above.
+        uses: arillso/.github/.github/workflows/ci-ansible-molecule.yml@2026-06-18
+        with:
+            collection_namespace: arillso
+            collection_name: system
+            driver: qemu
+            # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
+            python_version: "3.12"
+            scenarios: '["tuning"]'
+            concurrency-suffix: molecule-tuning
 
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-06-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,23 @@ tuning_optional_network_sysctl_params`. The previous single task
 
 ### Changed
 
+- **Molecule (KVM converge)**: the `zram` and `tuning` scenarios now run a real
+  converge + idempotence + verify under the `molecule-qemu` (KVM) driver on an
+  Ubuntu 22.04 cloud-image VM, instead of the previous docker-driver,
+  syntax-only run — a container has no own kernel, so neither role could be
+  exercised. `zram` loads the zram module, brings a zram swap device online and
+  verifies `/sys/block/zram0`, the `zramswap` service and `/dev/zram0` in
+  `swapon`. `tuning` applies the VM-supported subset (sysctls, swappiness, a
+  swap file, transparent hugepages) and verifies the sysctl values, the
+  drop-in file and the active swap file; GRUB-cmdline (reboot-only) and CPU
+  governor / I/O scheduler (virtual-HW dependent) are intentionally not
+  asserted. `thermal` stays on the docker driver and syntax-only: a cloud KVM
+  guest exposes no real thermal sensors, so a converge would only confirm a
+  package install. In CI the kernel-bound scenarios moved into dedicated
+  `molecule-zram` / `molecule-tuning` jobs with `driver: qemu` (the reusable
+  installs QEMU/KVM only for `driver: qemu`); the remaining docker scenarios
+  run in the `molecule` job via an explicit pinned `scenarios:` list, so the
+  drivers do not mix within a single job.
 - Align the release workflow with the org convention: set
   `name: Release - Ansible Collection`, simplify `run-name` to
   `Release <ref>`, use a `release-<ref>` concurrency group, and pin the

--- a/extensions/molecule/thermal/molecule.yml
+++ b/extensions/molecule/thermal/molecule.yml
@@ -1,6 +1,12 @@
 ---
-# thermal laedt Kernel-Module (coretemp), liest /sys/class/thermal und ruft
-# sensors-detect auf. Im Container nicht reproduzierbar — daher Syntax-only.
+# thermal loads the coretemp kernel module, runs sensors-detect and starts
+# thermald. Unlike zram/tuning this role was NOT converted to molecule-qemu:
+# a cloud KVM guest has no real thermal hardware. The virtual CPU exposes no
+# Intel coretemp device, so `modprobe coretemp` and sensors-detect find
+# nothing meaningful, and thermald has no zones to manage — a verify could
+# only assert "package installed", which is low-value. This scenario therefore
+# stays on the docker driver and runs syntax-only (real sensors are
+# unavailable in CI VMs). converge.yml is kept as a manual VM-run reference.
 
 dependency:
     name: galaxy

--- a/extensions/molecule/tuning/converge.yml
+++ b/extensions/molecule/tuning/converge.yml
@@ -1,17 +1,34 @@
 ---
-# Wird vom Syntax-only test_sequence nicht aufgerufen, dient aber als
-# Referenz fuer manuelle Vagrant/VM-Runs (`molecule converge -s tuning`).
+# Real converge against a KVM VM. The role applies the VM-supported subset:
+# sysctls, swappiness, a swap file and transparent hugepages all take effect
+# on a real kernel. The GRUB cmdline is still written by the role but needs a
+# reboot to take effect, so verify.yml does not assert it. CPU governor and
+# I/O scheduler stay at `auto` — they are gated on virtual-hardware detection
+# that largely no-ops in a guest. Kernel-module-dependent sysctls (e.g. the
+# bbr congestion control, removed/!built-in knobs) are marked optional so a
+# minimal cloud kernel that lacks them does not fail the converge.
 
-- name: Converge — arillso.system.tuning (VM-only, do not run in container)
+- name: Converge — arillso.system.tuning
   hosts: all
   become: true
 
   vars:
-      tuning_swap_file_enabled: false
-      tuning_network_tuning_enabled: false
+      tuning_swap_file_enabled: true
+      tuning_swap_file_path: /swapfile
+      tuning_swap_file_size_mb: 256
+      tuning_swap_swappiness: 10
+      tuning_network_tuning_enabled: true
       tuning_cpu_governor: "auto"
       tuning_io_scheduler: "auto"
       tuning_transparent_hugepages: madvise
+      # tuned ships `balanced` once installed (see prepare.yml).
+      tuning_tuned_profile: balanced
+      # Sysctls that depend on optional kernel modules or were removed in
+      # newer kernels; mark optional so a minimal cloud kernel cannot fail
+      # the required-sysctl loop.
+      tuning_optional_sysctl_params:
+          - net.ipv4.tcp_congestion_control
+          - net.ipv4.tcp_fack
 
   tasks:
       - name: Apply tuning role

--- a/extensions/molecule/tuning/molecule.yml
+++ b/extensions/molecule/tuning/molecule.yml
@@ -1,8 +1,12 @@
 ---
-# tuning aendert kernel-sysctls, GRUB-cmdline, ethtool, swap, transparent
-# hugepages und tuned-Profile. In Containern faellt davon das meiste durch
-# (kein eigener Kernel, kein /proc/sys-Write, kein swapon). Dieses Szenario
-# faehrt deshalb nur Syntax und Lint statt einem echten Converge.
+# tuning writes kernel sysctls, a swap file, transparent-hugepage settings,
+# the GRUB cmdline, I/O scheduler, CPU governor, ethtool ring buffers and a
+# tuned profile. A container has no own kernel, no writable /proc/sys and no
+# swapon, so it could only run syntax. A KVM VM has a real kernel: sysctl,
+# swap file and THP apply for real, so this scenario runs under molecule-qemu
+# and converges the VM-supported subset (GRUB needs a reboot to verify and is
+# only written, not asserted; CPU-governor/io-scheduler stay at `auto` and are
+# gated on virtual-hardware detection that mostly no-ops in a guest).
 
 dependency:
     name: galaxy
@@ -10,20 +14,18 @@ dependency:
         requirements-file: ../.config/requirements.yml
 
 driver:
-    name: docker
+    name: molecule-qemu
 
 platforms:
-    - name: tuning-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
-      command: /usr/lib/systemd/systemd
-      privileged: true
-      pre_build_image: true
-      cgroupns_mode: host
-      volumes:
-          - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      tmpfs:
-          - /run
-          - /run/lock
+    - name: tuning-ubuntu2204
+      image_url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+      image_checksum: sha256:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2223
+      network_ssh_user: ubuntu
+      vm_cpus: 2
+      vm_memory: 2048
 
 provisioner:
     name: ansible
@@ -34,20 +36,19 @@ provisioner:
         # molecule cd's into extensions/ before invoking ansible-playbook,
         # which then doesn't auto-detect the ansible_collections/ marker
         # two levels above. We also append the default user and system
-        # locations so the molecule docker driver's collections
-        # (community.docker, ansible.posix) stay resolvable.
+        # locations so any driver-provided collections stay resolvable.
         ANSIBLE_COLLECTIONS_PATH: ${GITHUB_WORKSPACE}:${HOME}/.ansible/collections:/usr/share/ansible/collections
     config_options:
         defaults:
             interpreter_python: auto_silent
-            stdout_callback: default
+            callbacks_enabled: profile_tasks, timer
+            stdout_callback: ansible.builtin.default
             result_format: yaml
-        ssh_connection:
-            pipelining: true
     inventory:
-        group_vars:
-            all:
-                ansible_user: root
+        host_vars:
+            tuning-ubuntu2204:
+                # cloud images log in as `ubuntu`; the role needs root.
+                ansible_become: true
 
 verifier:
     name: ansible
@@ -55,5 +56,13 @@ verifier:
 scenario:
     test_sequence:
         - dependency
+        - cleanup
         - destroy
         - syntax
+        - create
+        - prepare
+        - converge
+        - idempotence
+        - verify
+        - cleanup
+        - destroy

--- a/extensions/molecule/tuning/prepare.yml
+++ b/extensions/molecule/tuning/prepare.yml
@@ -1,0 +1,23 @@
+---
+# The tuning role starts and configures `tuned` whenever tuning_tuned_profile
+# is set. Ubuntu cloud images do not ship tuned, so install it (and refresh
+# the apt cache) before converge; otherwise the systemd service start would
+# fail on a missing unit. The `balanced` profile is part of the base tuned
+# package, so no extra profile package is needed.
+
+- name: Prepare — install tuned for the tuning converge
+  hosts: all
+  become: true
+
+  tasks:
+      - name: Update apt cache
+        ansible.builtin.apt:
+            update_cache: true
+            cache_valid_time: 3600
+        when: ansible_os_family == 'Debian'
+
+      - name: Install tuned
+        ansible.builtin.apt:
+            name: tuned
+            state: present
+        when: ansible_os_family == 'Debian'

--- a/extensions/molecule/tuning/verify.yml
+++ b/extensions/molecule/tuning/verify.yml
@@ -1,0 +1,68 @@
+---
+# Asserts the VM-supported tuning subset actually applied: representative
+# sysctls match the configured values at runtime, swappiness is set and the
+# swap file exists and is an active swap backend. GRUB-cmdline and CPU/IO
+# tuning are intentionally not asserted (reboot-only / virtual-HW dependent).
+
+- name: Verify — arillso.system.tuning
+  hosts: all
+  become: true
+
+  tasks:
+      - name: Read vm.dirty_ratio
+        ansible.builtin.command:
+            cmd: sysctl -n vm.dirty_ratio
+        register: tuning_dirty_ratio
+        changed_when: false
+
+      - name: Read vm.swappiness
+        ansible.builtin.command:
+            cmd: sysctl -n vm.swappiness
+        register: tuning_swappiness
+        changed_when: false
+
+      - name: Read fs.file-max
+        ansible.builtin.command:
+            cmd: sysctl -n fs.file-max
+        register: tuning_file_max
+        changed_when: false
+
+      - name: Assert sysctl values were applied
+        ansible.builtin.assert:
+            that:
+                - tuning_dirty_ratio.stdout | int == 10
+                - tuning_swappiness.stdout | int == 10
+                - tuning_file_max.stdout | int == 6815744
+            fail_msg: >-
+                sysctl values not applied
+                (dirty_ratio={{ tuning_dirty_ratio.stdout }},
+                swappiness={{ tuning_swappiness.stdout }},
+                file-max={{ tuning_file_max.stdout }})
+
+      - name: Check the sysctl drop-in file was written
+        ansible.builtin.stat:
+            path: /etc/sysctl.d/99-tuning.conf
+        register: tuning_sysctl_file
+
+      - name: Check the swap file exists
+        ansible.builtin.stat:
+            path: /swapfile
+        register: tuning_swapfile
+
+      - name: Read active swap devices
+        ansible.builtin.command:
+            cmd: swapon --show=NAME --noheadings
+        register: tuning_swapon
+        changed_when: false
+
+      - name: Assert sysctl drop-in and swap file are in place
+        ansible.builtin.assert:
+            that:
+                - tuning_sysctl_file.stat.exists
+                - tuning_swapfile.stat.exists
+                - "'/swapfile' in tuning_swapon.stdout"
+            fail_msg: >-
+                tuning config missing
+                (sysctl_file={{ tuning_sysctl_file.stat.exists }},
+                swapfile={{ tuning_swapfile.stat.exists }},
+                swapon='{{ tuning_swapon.stdout }}')

--- a/extensions/molecule/zram/converge.yml
+++ b/extensions/molecule/zram/converge.yml
@@ -1,8 +1,9 @@
 ---
-# Wird vom Syntax-only test_sequence nicht aufgerufen, dient aber als
-# Referenz fuer manuelle Vagrant/VM-Runs (`molecule converge -s zram`).
+# Real converge against a KVM VM with a true kernel. zram can load the
+# module, validate the algorithm against /sys/block/zram0 and bring the
+# swap device online here, which a container cannot do.
 
-- name: Converge — arillso.system.zram (VM-only, do not run in container)
+- name: Converge — arillso.system.zram
   hosts: all
   become: true
 

--- a/extensions/molecule/zram/molecule.yml
+++ b/extensions/molecule/zram/molecule.yml
@@ -1,9 +1,10 @@
 ---
-# zram lädt das zram-Kernelmodul, slurpt /sys/block/zram0/comp_algorithm
-# und ruft swapon -p. In Containern fehlt der eigene Kernel, /sys/block
-# ist read-only und swapon scheitert ohne Privilegien. Dieses Szenario
-# faehrt deshalb nur Syntax und Lint statt einem echten Converge — analog
-# zu tuning.
+# zram loads the zram kernel module (community.general.modprobe), slurps
+# /sys/block/zram0/comp_algorithm and calls swapon. A real kernel is
+# required for all of this, so this scenario runs under the molecule-qemu
+# (KVM) driver — a full Ubuntu cloud-image VM — and does a real
+# converge + idempotence + verify rather than the syntax-only run a
+# container can offer.
 
 dependency:
     name: galaxy
@@ -11,20 +12,18 @@ dependency:
         requirements-file: ../.config/requirements.yml
 
 driver:
-    name: docker
+    name: molecule-qemu
 
 platforms:
-    - name: zram-debian-bookworm
-      image: geerlingguy/docker-debian12-ansible:latest@sha256:1f76107285118095a97e14673de67ee7a4372a840b35223cd0c1212fdd3cf5b3
-      command: /usr/lib/systemd/systemd
-      privileged: true
-      pre_build_image: true
-      cgroupns_mode: host
-      volumes:
-          - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      tmpfs:
-          - /run
-          - /run/lock
+    - name: zram-ubuntu2204
+      image_url: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+      image_checksum: sha256:https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS
+      image_arch: x86_64
+      network_mode: user
+      network_ssh_port: 2222
+      network_ssh_user: ubuntu
+      vm_cpus: 2
+      vm_memory: 2048
 
 provisioner:
     name: ansible
@@ -35,20 +34,19 @@ provisioner:
         # molecule cd's into extensions/ before invoking ansible-playbook,
         # which then doesn't auto-detect the ansible_collections/ marker
         # two levels above. We also append the default user and system
-        # locations so the molecule docker driver's collections
-        # (community.docker, ansible.posix) stay resolvable.
+        # locations so any driver-provided collections stay resolvable.
         ANSIBLE_COLLECTIONS_PATH: ${GITHUB_WORKSPACE}:${HOME}/.ansible/collections:/usr/share/ansible/collections
     config_options:
         defaults:
             interpreter_python: auto_silent
-            stdout_callback: default
+            callbacks_enabled: profile_tasks, timer
+            stdout_callback: ansible.builtin.default
             result_format: yaml
-        ssh_connection:
-            pipelining: true
     inventory:
-        group_vars:
-            all:
-                ansible_user: root
+        host_vars:
+            zram-ubuntu2204:
+                # cloud images log in as `ubuntu`; the role needs root.
+                ansible_become: true
 
 verifier:
     name: ansible
@@ -56,5 +54,13 @@ verifier:
 scenario:
     test_sequence:
         - dependency
+        - cleanup
         - destroy
         - syntax
+        - create
+        - prepare
+        - converge
+        - idempotence
+        - verify
+        - cleanup
+        - destroy

--- a/extensions/molecule/zram/prepare.yml
+++ b/extensions/molecule/zram/prepare.yml
@@ -1,0 +1,23 @@
+---
+# Ubuntu cloud images ship the kvm kernel (linux-image-virtual) whose zram
+# module is not in the base image — it lives in linux-modules-extra-<kernel>.
+# The role installs that package itself (bootstrap.yml), but pulling it here
+# first keeps the converge focused on role behaviour and surfaces a missing
+# package as a prepare failure rather than a confusing modprobe error.
+
+- name: Prepare — ensure zram kernel module is installable
+  hosts: all
+  become: true
+
+  tasks:
+      - name: Update apt cache
+        ansible.builtin.apt:
+            update_cache: true
+            cache_valid_time: 3600
+        when: ansible_os_family == 'Debian'
+
+      - name: Install kernel modules-extra package for the running kernel
+        ansible.builtin.apt:
+            name: "linux-modules-extra-{{ ansible_kernel }}"
+            state: present
+        when: ansible_distribution == 'Ubuntu'

--- a/extensions/molecule/zram/verify.yml
+++ b/extensions/molecule/zram/verify.yml
@@ -1,0 +1,44 @@
+---
+# Asserts the role actually configured zram on the real kernel: the module
+# is loaded (device node present), the service is active and the zram device
+# is an online swap backend.
+
+- name: Verify — arillso.system.zram
+  hosts: all
+  become: true
+
+  tasks:
+      - name: Check zram device node exists (module loaded)
+        ansible.builtin.stat:
+            path: /sys/block/zram0
+        register: zram_dev
+
+      - name: Assert the zram kernel module is loaded
+        ansible.builtin.assert:
+            that:
+                - zram_dev.stat.exists
+            fail_msg: "/sys/block/zram0 missing — zram module not loaded"
+
+      - name: Query zramswap service state
+        ansible.builtin.service_facts:
+
+      - name: Assert zramswap service is running
+        ansible.builtin.assert:
+            that:
+                - "'zramswap.service' in ansible_facts.services"
+                - ansible_facts.services['zramswap.service'].state == 'running'
+            fail_msg: "zramswap.service is not active"
+
+      - name: Read active swap devices
+        ansible.builtin.command:
+            cmd: swapon --show=NAME --noheadings
+        register: zram_swapon
+        changed_when: false
+
+      - name: Assert the zram device is an active swap backend
+        ansible.builtin.assert:
+            that:
+                - "'/dev/zram0' in zram_swapon.stdout"
+            fail_msg: >-
+                /dev/zram0 not present in `swapon --show`
+                (found: {{ zram_swapon.stdout_lines | join(', ') }})

--- a/extensions/molecule/zram/verify.yml
+++ b/extensions/molecule/zram/verify.yml
@@ -22,12 +22,23 @@
       - name: Query zramswap service state
         ansible.builtin.service_facts:
 
-      - name: Assert zramswap service is running
+      # zramswap.service is a Type=oneshot unit with RemainAfterExit: it sets
+      # up the swap device and exits, so systemd reports it as "active (exited)"
+      # which service_facts surfaces as state "stopped". Assert it is enabled
+      # and not failed rather than "running"; the swapon check below is the real
+      # proof that the swap backend is live.
+      - name: Assert zramswap service is enabled and not failed
         ansible.builtin.assert:
             that:
                 - "'zramswap.service' in ansible_facts.services"
-                - ansible_facts.services['zramswap.service'].state == 'running'
-            fail_msg: "zramswap.service is not active"
+                - ansible_facts.services['zramswap.service'].status == 'enabled'
+                - ansible_facts.services['zramswap.service'].state != 'failed'
+            fail_msg: >-
+                zramswap.service is not enabled/active
+                (status={{ ansible_facts.services['zramswap.service'].status
+                | default('absent') }},
+                state={{ ansible_facts.services['zramswap.service'].state
+                | default('absent') }})
 
       - name: Read active swap devices
         ansible.builtin.command:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ black>=26.5.1
 # Testing
 molecule>=26.4.0
 molecule-plugins[docker]>=25.8.12
+molecule-qemu>=0.4.7
 pytest>=9.1.1
 pytest-ansible>=26.4.0
 pytest-cov>=7.1.0

--- a/roles/tuning/tasks/swap.yml
+++ b/roles/tuning/tasks/swap.yml
@@ -82,6 +82,18 @@
                 {{ line.split()[2] }}{%- endif -%}
                 {%- endfor -%}
 
+      # Resize decision uses a ±1 MiB tolerance, not an exact match. swapon
+      # reports the file size minus the mkswap header, and that overhead can
+      # exceed the 0.5 MiB rounding correction above (it grows on small files
+      # and varies by kernel), so an exact `current != target` comparison would
+      # recreate a correctly-sized swap file on every run and break idempotency.
+      - name: Determine whether the active swap file needs resizing
+        ansible.builtin.set_fact:
+            swap_needs_resize: >-
+                {{ current_swap_size != ""
+                   and ((current_swap_size | int)
+                        - (tuning_swap_file_size_mb | int)) | abs > 1 }}
+
 - name: Create or resize swap file
   block:
       # Kein Backup der Swap-Datei: Swap enthält nur flüchtige Pages, eine Kopie
@@ -112,16 +124,14 @@
         changed_when: true
         when:
             - swap_file_active
-            - current_swap_size != ""
-            - current_swap_size != (tuning_swap_file_size_mb | string)
+            - swap_needs_resize | bool
 
       - name: Refresh swap_file_active fact after swapoff
         ansible.builtin.set_fact:
             swap_file_active: false
         when:
             - swap_file_active
-            - current_swap_size != ""
-            - current_swap_size != (tuning_swap_file_size_mb | string)
+            - swap_needs_resize | bool
 
       - name: Remove existing swap file if resizing
         ansible.builtin.file:
@@ -130,8 +140,7 @@
         become: true
         when:
             - swap_file_stat.stat.exists
-            - current_swap_size != ""
-            - current_swap_size != (tuning_swap_file_size_mb | string)
+            - swap_needs_resize | bool
 
       - name: Create swap file using fallocate
         ansible.builtin.command: fallocate -l {{ tuning_swap_file_size_mb }}M {{ tuning_swap_file_path }}
@@ -140,8 +149,7 @@
         changed_when: fallocate_result.rc == 0
         failed_when: false
         when: >-
-            not swap_file_stat.stat.exists
-            or (current_swap_size != "" and current_swap_size != (tuning_swap_file_size_mb | string))
+            not swap_file_stat.stat.exists or (swap_needs_resize | bool)
 
       - name: Create swap file using dd (fallback)
         ansible.builtin.command: >-
@@ -194,8 +202,7 @@
         register: mkswap_result
         changed_when: mkswap_result.rc == 0
         when: >-
-            not swap_file_stat.stat.exists
-            or (current_swap_size != "" and current_swap_size != (tuning_swap_file_size_mb | string))
+            not swap_file_stat.stat.exists or (swap_needs_resize | bool)
 
       - name: Enable swap file
         ansible.builtin.command: swapon -p {{ tuning_swap_priority }} {{ tuning_swap_file_path }}


### PR DESCRIPTION
## Summary

- Convert the `zram` and `tuning` molecule scenarios from docker-driver syntax-only to the `molecule-qemu` (KVM) driver, so they run a real converge + idempotence + verify on an Ubuntu cloud image — a container has no kernel to load the zram module, write sysctls, or activate swap
- `zram`: prepare installs the kernel-module package; verify asserts `/sys/block/zram0`, the active `zramswap` service, and `/dev/zram0` as a swap backend
- `tuning`: converge applies the VM-supported subset (sysctls, swappiness, 256 MB swap file, THP), module-dependent sysctls optional, governor/scheduler at `auto`; verify asserts the sysctl values, the drop-in, and the active swap file
- `thermal` stays docker syntax-only — a cloud VM has no real thermal sensors, so converge could only assert package install (documented in its molecule.yml)
- CI: the reusable provisions QEMU/KVM only for `driver: qemu` and runs one driver per job → the single auto-discover job is pinned to the 13 docker scenarios; `zram`/`tuning` get dedicated `driver: qemu` jobs

Resolves the audited Notion ticket "Syntax-only Molecule-Szenarien zu Converge/Verify ausbauen".

## Test plan

- [ ] CI green — first run is the real smoke test for the KVM legs (zram module-load, tuned install) on `ubuntu-latest`
- [x] `ansible-lint` → 0 failures (production), all molecule.yml + workflow parse, markdownlint + prettier clean
- [ ] zram/tuning qemu legs boot + converge (KVM on free runner; falls back to slow TCG if `/dev/kvm` absent)