### PR TITLE
feat(meta): declare action_groups for the collection modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Collection metadata**: `meta/runtime.yml` now declares an `action_groups`
+  entry (`system`) listing `arillso.system.apt_update_info` and
+  `arillso.system.reboot_info`, so consumers can set `module_defaults` for the
+  whole group instead of per module.
 - **Role docs**: each role README now carries an inline `## Variables` table
   (key variables + defaults sourced from `defaults/main.yml`) and a
   `## Check Mode` section stating the role's `--check` support level, so the

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,12 @@
 ---
+# Runtime metadata for arillso.system collection
+# This file defines collection-level metadata and requirements
+
+# Minimum Ansible version required
 requires_ansible: ">=2.18.0"
+
+# Action groups let consumers set module_defaults for all modules at once
+action_groups:
+    system:
+        - arillso.system.apt_update_info
+        - arillso.system.reboot_info


### PR DESCRIPTION
## Summary

- `meta/runtime.yml` declared only `requires_ansible`, so the two modules this collection ships had no action group. Added a `system` group listing `arillso.system.apt_update_info` and `arillso.system.reboot_info`.
- Consumers can now set `module_defaults` once for the group instead of per module. Mirrors the existing `arillso_agent` group in the agent collection.

## Test plan

- [ ] `yamllint meta/runtime.yml` clean
- [ ] Group members match the modules actually shipped in `plugins/modules/`
- [ ] CI green