### PR TITLE
refactor(lint): rename yamllint config and raise line-length to 500

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,7 +3,7 @@ extends: default
 
 rules:
     line-length:
-        max: 160
+        max: 500
         level: warning
 
     comments:
@@ -17,7 +17,7 @@ rules:
         check-multi-line-strings: false
 
     truthy:
-        allowed-values: ['true', 'false']
+        allowed-values: ["true", "false"]
         check-keys: false
 
     brackets:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Key roles:
 
 - `galaxy.yml` - Ansible Galaxy collection metadata
 - `.ansible-lint` - Ansible lint configuration
-- `.yamllint` - YAML linting rules
+- `.yamllint.yml` - YAML linting rules
 - `lefthook.yml` - Local git hooks (prettier, yamllint, markdownlint, ansible-lint, actionlint, gitleaks)
 - `REVIEW.md` - Code review guidelines (read by the `ai-claude-review` workflow)
 - `.python-version` - Pinned Python version for plugin development (3.12)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ git checkout -b fix/issue-description
 - Use 4 spaces for indentation (no tabs)
 - Use lowercase with underscores for variable names
 - Prefix role variables with the role name
-- Keep lines under 160 characters
+- Keep lines under 500 characters
 - Require `---` document start
 
 ### Python

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,7 +21,7 @@ pre-commit:
         yamllint:
             glob: "*.{yml,yaml}"
             exclude: "(^\\.ansible/)"
-            run: yamllint -c .yamllint {staged_files}
+            run: yamllint -c .yamllint.yml {staged_files}
         markdownlint:
             glob: "*.md"
             exclude: "(^\\.ansible/)"


### PR DESCRIPTION
## Summary

- Rename `.yamllint` to `.yamllint.yml` so the config matches the org-wide filename convention and is picked up by tooling that expects the `.yml` extension.
- Raise `line-length.max` from 160 to 500, keeping `level: warning`, to match the org norm.
- Update the references that named the old file or limit: the hardcoded `-c .yamllint` path in `lefthook.yml`, the config list in `AGENTS.md`, and the YAML line-length rule in `CONTRIBUTING.md`.
- Reformat the quote style in `truthy.allowed-values` (`'true'` to `"true"`). This is a no-op for yamllint and not a deliberate change: the rename makes the file match Prettier's `*.yml` glob for the first time, so the pre-commit hook now formats it.

## Test plan

- [x] `yamllint .` passes — confirms the config is still auto-discovered after the rename
- [x] `make lint-yaml` passes
- [x] `yamllint -c .yamllint.yml lefthook.yml` passes — confirms the corrected explicit path resolves
- [x] lefthook pre-commit hooks green (gitleaks, yamllint, prettier, markdownlint)
- [x] CI green (36 checks)
