### PR TITLE
docs(license): update copyright year range and organization name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 arillso
+Copyright (c) 2025-2026 Arillso
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Update the LICENSE copyright line from `2025 arillso` to `2025-2026 Arillso`
- Aligns the file with the canonical format used across the other repositories: `MIT License`, blank line, `Copyright (c) <first year>-2026 Arillso`

## Test plan

- [ ] CI green, local lints green