### PR TITLE
ci(security): wire CodeQL, Trivy IaC and SBOM into the nightly scan

### DIFF
--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -49,9 +49,11 @@ jobs:
     security-sbom:
         # Filesystem SBOM: the collection ships no container image and no Go
         # module, so `filesystem` over the repo root is the applicable type.
-        # attach-to-release stays off — this workflow never runs on a tag ref.
+        # read is enough: at @2026-06-18 the reusable only generates the SBOM
+        # and stores it via upload-artifact, which needs no contents scope.
+        # It has no release-attach step, so nothing here writes to the repo.
         permissions:
-            contents: write
+            contents: read
         uses: arillso/.github/.github/workflows/security-sbom.yml@2026-06-18
         with:
             artifact-type: filesystem

--- a/.github/workflows/nightly-security.yml
+++ b/.github/workflows/nightly-security.yml
@@ -20,3 +20,40 @@ permissions:
 jobs:
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-06-18
+
+    security-code:
+        # CodeQL over the collection's Python: plugins/{filter,lookup,modules}.
+        # security-code.yml, not the legacy Go-only security-codeql.yml.
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
+        uses: arillso/.github/.github/workflows/security-code.yml@2026-06-18
+        with:
+            languages: '["python"]'
+            concurrency-suffix: security-code
+
+    security-config:
+        # Trivy IaC scan over the roles. Reports only — fail-on-findings stays
+        # false so a nightly finding surfaces in the Security tab without
+        # turning the scheduled run red.
+        permissions:
+            contents: read
+            security-events: write
+        uses: arillso/.github/.github/workflows/security-config.yml@2026-06-18
+        with:
+            scan-ansible: true
+            ansible-path: roles
+            concurrency-suffix: security-config
+
+    security-sbom:
+        # Filesystem SBOM: the collection ships no container image and no Go
+        # module, so `filesystem` over the repo root is the applicable type.
+        # attach-to-release stays off — this workflow never runs on a tag ref.
+        permissions:
+            contents: write
+        uses: arillso/.github/.github/workflows/security-sbom.yml@2026-06-18
+        with:
+            artifact-type: filesystem
+            artifact-ref: .
+            concurrency-suffix: security-sbom


### PR DESCRIPTION
## Summary

- The nightly scan ran secret detection only; the collection's Python plugins (`plugins/{filter,lookup,modules}`) and the roles were never scanned. Wires `security-code.yml` (CodeQL, Python), `security-config.yml` (Trivy IaC over `roles/`) and `security-sbom.yml` (filesystem SBOM).
- `security-code.yml` is used instead of `security-codeql.yml` — the latter is the legacy Go-only workflow per `arillso/.github/AGENTS.md` and does not cover Python.
- `fail-on-findings` stays at its `false` default so a nightly finding surfaces in the Security tab without turning the scheduled run red.
- Each call gets a `concurrency-suffix`; without one all three would share the caller's group (`Nightly Security Scan-<ref>`) and cancel each other.
- The SBOM job runs with `contents: read`. At the pinned tag the reusable only generates the SBOM and stores it via `upload-artifact` (no `contents` scope needed) and carries no release-attach step.

## Not included

`security-deps.yml` was part of the same intake card but is left unwired: its `go-audit` job carries no `if:` guard and pins `setup-go` to `go-version-file: go.mod`, which this repo does not have. Wiring it would fail the run every night. Only the `dependency-review` job would apply here, and that needs an upstream guard first.

## Test plan

- [x] `actionlint` and `yamllint` clean locally
- [x] Reusables verified to exist at the pinned tag `2026-06-18`; the `security-sbom` job list and step contract read directly from that tag
- [x] CI green (34 pass, 2 skipped) on the wiring commit
- [ ] After merge: trigger via `workflow_dispatch` and confirm all four jobs run and report to the Security tab
