### PR TITLE
feat(firewall): rate-limit new SSH connections and log policy drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **firewall**: the default input chain now rate-limits new SSH connections
+  (`firewall_ssh_rate_limit`, default `10/minute` with a burst of 5) and logs
+  packets before the chain policy drops them (`firewall_log_drop_prefix`,
+  capped by `firewall_log_drop_rate_limit`). The rate limit matches on
+  `ct state new` only, so established sessions are never throttled. Hosts that
+  legitimately open many short-lived SSH connections (CI runners, bastions)
+  should raise `firewall_ssh_rate_limit` rather than remove the rule.
+
 ### Added
 
+- **firewall**: rule-level `limit` and `burst` keys are now declared in
+  `meta/argument_specs.yml`. The filter plugin already rendered them, but
+  argument validation rejected them without the spec entries.
 - **Collection metadata**: `meta/runtime.yml` now declares an `action_groups`
   entry (`system`) listing `arillso.system.apt_update_info` and
   `arillso.system.reboot_info`, so consumers can set `module_defaults` for the

--- a/extensions/molecule/firewall/converge.yml
+++ b/extensions/molecule/firewall/converge.yml
@@ -27,9 +27,17 @@
                           - comment: "Accept established"
                             ct_state: ["established", "related"]
                             action: accept
-                          - comment: "Accept SSH"
+                          - comment: "Accept new SSH connections, rate-limited"
                             tcp_dport: 22
+                            ct_state: ["new"]
+                            limit: "10/minute"
+                            burst: 5
                             action: accept
+                          - comment: "Log packets before the chain policy drops them"
+                            limit: "5/minute"
+                            log_prefix: "nft-drop-input: "
+                            log_level: info
+                            action: drop
 
   tasks:
       - name: Render hierarchical firewall payload only

--- a/extensions/molecule/firewall/verify.yml
+++ b/extensions/molecule/firewall/verify.yml
@@ -4,6 +4,13 @@
   become: true
   gather_facts: false
 
+  vars:
+      _nft_ssh_rule: >-
+          tcp dport 22 ct state new limit rate 10/minute burst 5 packets accept
+      # Single-quoted so the double quotes nftables puts around the log prefix
+      # stay literal.
+      _nft_log_rule: 'log prefix "nft-drop-input: " level info drop'
+
   tasks:
       - name: Confirm rendered ruleset exists and is non-empty
         ansible.builtin.stat:
@@ -15,6 +22,23 @@
             that:
                 - _nft.stat.exists
                 - _nft.stat.size > 0
+
+      - name: Read back the rendered ruleset
+        ansible.builtin.slurp:
+            src: /etc/nftables.conf
+        register: _nft_content
+
+      # A non-empty file is not a correct one: assert that the rate limit
+      # really lands on ct state new (never on established sessions) and that
+      # the log-on-drop survived rendering.
+      - name: Assert SSH rate-limiting and log-on-drop rendered
+        vars:
+            _nft_text: "{{ _nft_content.content | b64decode }}"
+        ansible.builtin.assert:
+            that:
+                - _nft_ssh_rule in _nft_text
+                - _nft_log_rule in _nft_text
+            fail_msg: "Expected rate-limit and log-on-drop rules missing from /etc/nftables.conf"
 
       # See converge.yml: `nft -c -f` dry-runs against the kernel and exits
       # 2 with an empty stderr on a container missing conntrack modules,

--- a/roles/firewall/README.md
+++ b/roles/firewall/README.md
@@ -31,12 +31,18 @@ For detailed documentation including all variables, examples, and usage instruct
 
 ## Variables
 
-| Variable          | Default   | Description                                                                                                                                                                                 |
-| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `firewall`        | `[{...}]` | Base nftables ruleset: an `inet filter` table with input/forward (policy `drop`) and output (policy `accept`) chains; input accepts loopback, established/related, and SSH (`tcp_dport 22`) |
-| `firewall_global` | `[]`      | Global-level rules merged on top of the base                                                                                                                                                |
-| `firewall_group`  | `[]`      | Group-level rules merged on top of global                                                                                                                                                   |
-| `firewall_host`   | `[]`      | Host-level rules merged last (highest precedence)                                                                                                                                           |
+| Variable                       | Default                            | Description                                                                                                                                                                                                                |
+| ------------------------------ | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `firewall`                     | `[{...}]`                          | Base nftables ruleset: an `inet filter` table with input/forward (policy `drop`) and output (policy `accept`) chains; input accepts loopback, established/related and new SSH connections, then logs what the policy drops |
+| `firewall_ssh_rate_limit`      | `10/minute`                        | Rate limit for **new** SSH connections. Established sessions match the preceding established/related rule and are never throttled                                                                                          |
+| `firewall_ssh_rate_burst`      | `5`                                | Burst allowance in packets on top of the SSH rate limit                                                                                                                                                                    |
+| `firewall_log_drop_rate_limit` | `5/minute`                         | Rate limit for the log-on-drop rule; caps log volume independently of traffic                                                                                                                                              |
+| `firewall_log_drop_prefix`     | `nft-drop-input:` + trailing space | Log prefix for packets dropped by the input chain policy. Keep the trailing space — nftables appends the packet details directly after it                                                                                  |
+| `firewall_global`              | `[]`                               | Global-level rules merged on top of the base                                                                                                                                                                               |
+| `firewall_group`               | `[]`                               | Group-level rules merged on top of global                                                                                                                                                                                  |
+| `firewall_host`                | `[]`                               | Host-level rules merged last (highest precedence)                                                                                                                                                                          |
+
+Raise `firewall_ssh_rate_limit` on hosts that legitimately open many short-lived SSH connections (CI runners, bastions) rather than removing the rule.
 
 See [`defaults/main.yml`](defaults/main.yml) for the complete list and [the guide](https://guide.arillso.io/collections/arillso/system/firewall_role.html) for detailed docs.
 

--- a/roles/firewall/defaults/main.yml
+++ b/roles/firewall/defaults/main.yml
@@ -1,5 +1,15 @@
 ---
-firewall:  # noqa: argument-specs
+# Tunables for the default input chain below. A bastion behind a CI runner
+# that opens many short-lived sessions needs a higher ceiling than a single
+# admin host — raise firewall_ssh_rate_limit there rather than dropping the
+# rule. Set firewall_log_drop_prefix to "" only if the drop log is noisy
+# enough to matter; the rate limit already caps it.
+firewall_ssh_rate_limit: "10/minute"
+firewall_ssh_rate_burst: 5
+firewall_log_drop_rate_limit: "5/minute"
+firewall_log_drop_prefix: "nft-drop-input: "
+
+firewall: # noqa: argument-specs
     - table:
           name: filter
           family: inet
@@ -16,9 +26,26 @@ firewall:  # noqa: argument-specs
                     - comment: "Accept established and related connections"
                       ct_state: ["established", "related"]
                       action: accept
-                    - comment: "Accept SSH traffic"
+                    # Rate-limited on ct_state new only: established SSH
+                    # sessions already match the rule above, so the limit
+                    # applies to connection attempts and never throttles a
+                    # session that is already up. Without the ct_state match
+                    # a busy interactive session would eat its own budget.
+                    - comment: "Accept new SSH connections, rate-limited"
                       tcp_dport: 22
+                      ct_state: ["new"]
+                      limit: "{{ firewall_ssh_rate_limit }}"
+                      burst: "{{ firewall_ssh_rate_burst }}"
                       action: accept
+                    # Anything reaching here is dropped by the chain policy
+                    # anyway; this rule only makes the drop visible. It must
+                    # stay last — an earlier log-and-drop would shadow the
+                    # accepts above.
+                    - comment: "Log packets before the chain policy drops them"
+                      limit: "{{ firewall_log_drop_rate_limit }}"
+                      log_prefix: "{{ firewall_log_drop_prefix }}"
+                      log_level: info
+                      action: drop
               - name: forward
                 type: filter
                 hook: forward

--- a/roles/firewall/meta/argument_specs.yml
+++ b/roles/firewall/meta/argument_specs.yml
@@ -8,6 +8,30 @@ argument_specs:
             - Direct mapping from YAML to nftables configuration
 
         options:
+            firewall_ssh_rate_limit:
+                description:
+                    - Rate limit for new SSH connections in the default input chain
+                    - nftables rate syntax, e.g. "10/minute" or "5/second"
+                type: str
+                required: false
+                default: "10/minute"
+            firewall_ssh_rate_burst:
+                description: Burst allowance in packets for the SSH rate limit
+                type: int
+                required: false
+                default: 5
+            firewall_log_drop_rate_limit:
+                description:
+                    - Rate limit for the log-on-drop rule in the default input chain
+                    - Caps how much the drop log can write, independent of traffic volume
+                type: str
+                required: false
+                default: "5/minute"
+            firewall_log_drop_prefix:
+                description: Log prefix for packets dropped by the input chain policy
+                type: str
+                required: false
+                default: "nft-drop-input: "
             firewall:
                 description: "Main nftables configuration with default filter table (input/forward/output chains)"
                 type: list
@@ -219,6 +243,19 @@ argument_specs:
                                             meta_protocol:
                                                 description: Protocol type
                                                 type: str
+                                                required: false
+                                            # Rate limiting
+                                            limit:
+                                                description:
+                                                    Rate limit in nftables syntax (e.g.
+                                                    "10/minute", "5/second")
+                                                type: str
+                                                required: false
+                                            burst:
+                                                description:
+                                                    Burst allowance in packets, applied on top
+                                                    of limit. Has no effect without limit.
+                                                type: int
                                                 required: false
                                             log_prefix:
                                                 description: Log prefix for logging rules

--- a/tests/unit/plugins/filter/test_nftables.py
+++ b/tests/unit/plugins/filter/test_nftables.py
@@ -60,6 +60,35 @@ class TestRuleToNft:
         assert "level warn" in result
         assert result.endswith("drop")
 
+    def test_rate_limit_with_burst(self, fm):
+        rule = {"limit": "10/minute", "burst": 5, "action": "accept"}
+        assert fm.rule_to_nft(rule) == "limit rate 10/minute burst 5 packets accept"
+
+    def test_rate_limit_without_burst(self, fm):
+        assert fm.rule_to_nft({"limit": "5/second", "action": "drop"}) == "limit rate 5/second drop"
+
+    def test_burst_from_jinja_renders_like_int(self, fm):
+        # A default resolved through Jinja arrives as a string, so "5" and 5
+        # have to produce the same rule — otherwise the shipped defaults would
+        # render differently than this test suite exercises them.
+        as_int = fm.rule_to_nft({"limit": "10/minute", "burst": 5, "action": "accept"})
+        as_str = fm.rule_to_nft({"limit": "10/minute", "burst": "5", "action": "accept"})
+        assert as_int == as_str
+
+    def test_ssh_accept_matches_shipped_default(self, fm):
+        # The default input chain rate-limits on ct_state new only: an
+        # established session must not consume the connection budget.
+        rule = {
+            "tcp_dport": 22,
+            "ct_state": ["new"],
+            "limit": "10/minute",
+            "burst": 5,
+            "action": "accept",
+        }
+        assert fm.rule_to_nft(rule) == (
+            "tcp dport 22 ct state new limit rate 10/minute burst 5 packets accept"
+        )
+
 
 class TestMergeNftablesStructure:
     def _base(self) -> dict:


### PR DESCRIPTION
## Summary

- The default input chain accepted SSH unconditionally and dropped everything else silently. New SSH connections are now rate-limited (`10/minute`, burst 5) and the chain logs packets before the policy drops them.
- The rate limit matches on `ct state new` **only**. Established sessions are already accepted by the preceding `ct state established,related` rule, so an interactive session cannot exhaust its own connection budget — a limit without that match would throttle live logins.
- The log-on-drop rule is itself rate-capped (`5/minute`) so a flood cannot fill the journal, and it stays last in the chain: an earlier log-and-drop would shadow the accepts above it.
- All four values are variables (`firewall_ssh_rate_limit`, `firewall_ssh_rate_burst`, `firewall_log_drop_rate_limit`, `firewall_log_drop_prefix`). Hosts that legitimately open many short-lived SSH connections should raise the limit rather than remove the rule.
- Rule-level `limit` and `burst` were already rendered by the filter plugin (`plugins/filter/nftables.py:285-290`) but were **not** declared in `meta/argument_specs.yml`, so argument validation would have rejected them. Now declared.

## Test plan

- [x] `pytest tests/unit/` — 45 passed, including 4 new cases: limit with/without burst, string-vs-int burst equivalence (Jinja delivers `"5"`, not `5`), and the exact shipped SSH rule
- [x] Rendered the shipped defaults through the real template and filter; verified rule order and output
- [x] Rendered ruleset parsed with `nft -c -f`: no parser diagnostic (a deliberately broken control file *does* produce one, confirming the parser ran — `nft` cannot fully verify as non-root because its netlink cache needs privileges)
- [x] `ansible-lint roles/firewall/` clean at `production` profile; yamllint, markdownlint, prettier clean
- [ ] CI green, incl. the `molecule / Molecule (firewall)` scenario — `verify.yml` now asserts both rules are present in the rendered config instead of only checking the file is non-empty