### PR TITLE
refactor(roles): access facts via ansible_facts instead of top-level vars

### DIFF
--- a/extensions/molecule/tuning/prepare.yml
+++ b/extensions/molecule/tuning/prepare.yml
@@ -14,10 +14,10 @@
         ansible.builtin.apt:
             update_cache: true
             cache_valid_time: 3600
-        when: ansible_os_family == 'Debian'
+        when: ansible_facts['os_family'] == 'Debian'
 
       - name: Install tuned
         ansible.builtin.apt:
             name: tuned
             state: present
-        when: ansible_os_family == 'Debian'
+        when: ansible_facts['os_family'] == 'Debian'

--- a/extensions/molecule/zram/prepare.yml
+++ b/extensions/molecule/zram/prepare.yml
@@ -14,10 +14,10 @@
         ansible.builtin.apt:
             update_cache: true
             cache_valid_time: 3600
-        when: ansible_os_family == 'Debian'
+        when: ansible_facts['os_family'] == 'Debian'
 
       - name: Install kernel modules-extra package for the running kernel
         ansible.builtin.apt:
-            name: "linux-modules-extra-{{ ansible_kernel }}"
+            name: "linux-modules-extra-{{ ansible_facts['kernel'] }}"
             state: present
-        when: ansible_distribution == 'Ubuntu'
+        when: ansible_facts['distribution'] == 'Ubuntu'

--- a/roles/access/vars/main.yml
+++ b/roles/access/vars/main.yml
@@ -11,7 +11,7 @@ _access_ssh_service_names:
 
 # Dynamically selected SSH service name
 _access_ssh_service_name: >-
-    {{ _access_ssh_service_names[ansible_os_family] |
+    {{ _access_ssh_service_names[ansible_facts['os_family']] |
        default(_access_ssh_service_names['default']) }}
 
 # Sudoers file validation command by OS family

--- a/roles/ansible/templates/etc/ansible/ansible.env.j2
+++ b/roles/ansible/templates/etc/ansible/ansible.env.j2
@@ -10,5 +10,5 @@ OTEL_EXPORTER_OTLP_ENDPOINT={{ ansible_otel_endpoint }}
 OTEL_EXPORTER_OTLP_HEADERS={{ ansible_otel_headers }}
 {% endif %}
 OTEL_SERVICE_NAME={{ ansible_otel_service_name }}
-OTEL_RESOURCE_ATTRIBUTES=service.instance.id={{ inventory_hostname }},workload.type={{ ansible_otel_workload_type }},host.name={{ ansible_hostname }},deployment.environment={{ ansible_otel_environment }}
+OTEL_RESOURCE_ATTRIBUTES=service.instance.id={{ inventory_hostname }},workload.type={{ ansible_otel_workload_type }},host.name={{ ansible_facts['hostname'] }},deployment.environment={{ ansible_otel_environment }}
 {% endif %}

--- a/roles/ansible/vars/main.yml
+++ b/roles/ansible/vars/main.yml
@@ -5,4 +5,4 @@ _ansible_arch_map:
     aarch64: aarch64
     armv7l: armv7l
 
-_ansible_detected_arch: "{{ _ansible_arch_map[ansible_architecture] | default('x86_64') }}"
+_ansible_detected_arch: "{{ _ansible_arch_map[ansible_facts['architecture']] | default('x86_64') }}"

--- a/roles/bitwarden_secrets/defaults/main.yml
+++ b/roles/bitwarden_secrets/defaults/main.yml
@@ -6,7 +6,7 @@ bitwarden_secrets_install_path: "/usr/local/bin"
 bitwarden_secrets_binary_name: "bws"
 
 # Architecture Detection
-bitwarden_secrets_arch: "{{ _bitwarden_secrets_arch_map[ansible_architecture] | default('x86_64-unknown-linux-gnu') }}"
+bitwarden_secrets_arch: "{{ _bitwarden_secrets_arch_map[ansible_facts['architecture']] | default('x86_64-unknown-linux-gnu') }}"
 
 # Download Configuration
 bitwarden_secrets_download_url: >-

--- a/roles/bitwarden_secrets/meta/argument_specs.yml
+++ b/roles/bitwarden_secrets/meta/argument_specs.yml
@@ -20,7 +20,7 @@ argument_specs:
                 type: str
                 default: "bws"
             bitwarden_secrets_arch:
-                description: "Target architecture for the bws binary (auto-detected from ansible_architecture)"
+                description: "Target architecture for the bws binary (auto-detected from ansible_facts['architecture'])"
                 type: str
             bitwarden_secrets_download_url:
                 description: "Full download URL for the bws release archive (auto-constructed from version and arch)"

--- a/roles/facts/handlers/main.yml
+++ b/roles/facts/handlers/main.yml
@@ -25,7 +25,7 @@
   # scripts. A handler only fires when something upstream notified it,
   # so reporting the run as changed (the default) matches reality.
   ansible.builtin.command: update-motd
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
   changed_when: true
   listen: "facts: update motd"
   tags:

--- a/roles/facts/templates/etc/ansible/facts.d/run.fact.j2
+++ b/roles/facts/templates/etc/ansible/facts.d/run.fact.j2
@@ -64,7 +64,7 @@ main() {
         --arg role_path "{{ role_path | default('unknown') }}" \
         --argjson tags '{{ facts_system_tags | default(['facts', 'metadata']) | to_json }}' \
         --arg owner "{{ facts_system_owner | default(ansible_user | default('ops')) }}" \
-        --arg node_type "{{ facts_node_type | default(ansible_virtualization_type | default('unknown')) }}" \
+        --arg node_type "{{ facts_node_type | default(ansible_facts['virtualization_type'] | default('unknown')) }}" \
         --arg ansible_user "{{ ansible_user | default(ansible_env.USER | default('system')) }}" \
         --arg ansible_host "{{ ansible_host | default(inventory_hostname) }}" \
         --arg ansible_connection "{{ ansible_connection | default('ssh') }}" \

--- a/roles/facts/templates/etc/ansible/facts.d/security.fact.j2
+++ b/roles/facts/templates/etc/ansible/facts.d/security.fact.j2
@@ -110,13 +110,13 @@ safe_exec() {
 get_security_updates() {
     local security_updates=0
 
-{% if ansible_os_family == "Debian" %}
+{% if ansible_facts['os_family'] == "Debian" %}
     if command -v apt >/dev/null 2>&1; then
         # Debian/Ubuntu: Check for security updates
         security_updates=$(safe_exec "apt list --upgradable 2>/dev/null | grep -c 'security\|security-updates'" "0" "${SECURITY_TIMEOUT}")
         log_debug "Debian security updates found: $security_updates"
     fi
-{% elif ansible_os_family == "RedHat" %}
+{% elif ansible_facts['os_family'] == "RedHat" %}
     if command -v yum >/dev/null 2>&1; then
         # RHEL/CentOS with yum
         security_updates=$(safe_exec "yum check-update --security -q 2>/dev/null | grep -v '^$' | wc -l" "0" "${SECURITY_TIMEOUT}")
@@ -158,7 +158,7 @@ collect_security_facts() {
         --arg iso_timestamp "$iso_timestamp" \
         --arg human_timestamp "$human_timestamp" \
         --arg epoch_timestamp "$epoch_timestamp" \
-        --arg check_method "{{ ansible_os_family }}" \
+        --arg check_method "{{ ansible_facts['os_family'] }}" \
         '{
             security_updates_available: ($security_updates | tonumber),
             meta: {

--- a/roles/facts/templates/etc/ansible/facts.d/system.fact.j2
+++ b/roles/facts/templates/etc/ansible/facts.d/system.fact.j2
@@ -197,8 +197,8 @@ collect_cloud_provider_info() {
     fqdn=$(safe_exec "hostname -f" "{{ ansible_facts['fqdn'] }}")
     processor_cores=$(get_numeric_value "nproc" "{{ ansible_facts['processor_cores'] | default(1) }}")
     memory_mb=$(get_numeric_value "free -m | awk 'NR==2{print \$2}'" "{{ ansible_facts['memtotal_mb'] | default(0) }}")
-    ipv4="{{ ansible_default_ipv4.address | default('') }}"
-    ipv6="{{ ansible_default_ipv6.address | default('') }}"
+    ipv4="{{ ansible_facts['default_ipv4'].address | default('') }}"
+    ipv6="{{ ansible_facts['default_ipv6'].address | default('') }}"
 
     # Build JSON object conditionally
     local json_base
@@ -226,7 +226,7 @@ collect_cloud_provider_info() {
 
 # Collect security update information (semi-static - changes weekly/monthly)
 collect_security_updates() {
-{% if ansible_os_family == "Debian" %}
+{% if ansible_facts['os_family'] == "Debian" %}
     if command -v apt &> /dev/null; then
         local security_updates
         security_updates=$(get_numeric_value "apt list --upgradable 2>/dev/null | grep -c security" "0")
@@ -235,7 +235,7 @@ collect_security_updates() {
     else
         jq -n '{security_updates_available: 0}'
     fi
-{% elif ansible_os_family == "RedHat" %}
+{% elif ansible_facts['os_family'] == "RedHat" %}
     if command -v yum &> /dev/null; then
         local security_updates
         security_updates=$(get_numeric_value "yum check-update --security 2>/dev/null | grep -c 'Needed'" "0")

--- a/roles/network/tasks/main.yml
+++ b/roles/network/tasks/main.yml
@@ -10,5 +10,5 @@
         ansible.builtin.include_tasks: netplan.yml
         when:
             - network_netplan_enabled | default(false) | bool
-            - ansible_distribution == "Ubuntu"
+            - ansible_facts['distribution'] == "Ubuntu"
         tags: ["network", "netplan"]

--- a/roles/packages/defaults/main.yml
+++ b/roles/packages/defaults/main.yml
@@ -50,7 +50,7 @@ packages_apt_proxy_socks: ""
 # APT Mirror/Sources Configuration
 packages_apt_mirror_enabled: false
 packages_apt_mirror_uri: ""
-packages_apt_mirror_distribution: "{{ ansible_distribution_release }}"
+packages_apt_mirror_distribution: "{{ ansible_facts['distribution_release'] }}"
 packages_apt_mirror_components:
     - main
     - restricted

--- a/roles/packages/meta/argument_specs.yml
+++ b/roles/packages/meta/argument_specs.yml
@@ -254,7 +254,7 @@ argument_specs:
                 type: str
                 default: ""
             packages_apt_mirror_distribution:
-                description: "APT mirror distribution. Defaults to ansible_distribution_release."
+                description: "APT mirror distribution. Defaults to ansible_facts['distribution_release']."
                 type: str
             packages_apt_mirror_components:
                 description: "APT mirror components"

--- a/roles/packages/tasks/cache.yml
+++ b/roles/packages/tasks/cache.yml
@@ -6,7 +6,7 @@
 
 - name: Calculate cache age
   ansible.builtin.set_fact:
-      _cache_age: "{{ ansible_date_time.epoch | int - _apt_cache_stat.stat.mtime | default(0) | int }}"
+      _cache_age: "{{ ansible_facts['date_time'].epoch | int - _apt_cache_stat.stat.mtime | default(0) | int }}"
   when: _apt_cache_stat.stat.exists
 
 - name: Set cache age to max if stamp doesn't exist

--- a/roles/thermal/defaults/main.yml
+++ b/roles/thermal/defaults/main.yml
@@ -9,7 +9,7 @@ thermal_packages:
     - thermald
 
 # Platform name
-thermal_platform_name: "{{ ansible_product_name | default('Generic') }}"
+thermal_platform_name: "{{ ansible_facts['product_name'] | default('Generic') }}"
 
 # Thermal preference: QUIET, PERFORMANCE, or BALANCED
 thermal_preference: "QUIET"

--- a/roles/thermal/meta/argument_specs.yml
+++ b/roles/thermal/meta/argument_specs.yml
@@ -25,7 +25,7 @@ argument_specs:
                     - thermald
 
             thermal_platform_name:
-                description: "Platform name for thermal configuration (auto-detected from ansible_product_name)"
+                description: "Platform name for thermal configuration (auto-detected from ansible_facts['product_name'])"
                 type: "str"
                 required: false
 

--- a/roles/zram/defaults/main.yml
+++ b/roles/zram/defaults/main.yml
@@ -29,10 +29,10 @@ zram_packages:
 # zram_kernel_module_package: package that provides the zram kernel module.
 # On Ubuntu cloud images with linux-image-virtual the module is not part of
 # the base image — it lives in linux-modules-extra-<kernel>, resolved against
-# the running kernel (ansible_kernel) so kernel upgrades pull the matching
+# the running kernel (ansible_facts['kernel']) so kernel upgrades pull the matching
 # package automatically. Debian ships the module in the stock kernel and has
 # no linux-modules-extra-* package, so the default is empty there and the
 # install step is skipped. Set explicitly to override per host.
 zram_kernel_module_package: >-
-    {{ 'linux-modules-extra-' ~ ansible_kernel
-       if ansible_distribution == 'Ubuntu' else '' }}
+    {{ 'linux-modules-extra-' ~ ansible_facts['kernel']
+       if ansible_facts['distribution'] == 'Ubuntu' else '' }}


### PR DESCRIPTION
## Summary

- `INJECT_FACTS_AS_VARS` defaults to `False` in ansible-core 2.24, after which top-level fact names such as `ansible_os_family` are no longer injected and evaluate as undefined. This migrates them to `ansible_facts['<name>']`, completing a migration the collection had already started (`roles/shell`, `roles/python`, `roles/firewall` were on the target style).
- Covers the eight roles outside `roles/tuning` (`access`, `ansible`, `bitwarden_secrets`, `facts`, `network`, `packages`, `thermal`, `zram`) plus both molecule `prepare.yml` playbooks, and the matching `argument_specs.yml` descriptions.
- `roles/tuning` is intentionally left for a follow-up PR: its `setup` task passes `filter: [ansible_processor*, ansible_devices, ansible_interfaces]`, which matches against fact names rather than injected variables. That change can alter runtime behaviour and its consumers fall back silently to `default('unknown')`, so it needs the qemu molecule scenario as its own gate rather than being buried in this diff.

Replacements were made per fact name against the documented fact list, never as a pattern substitution — `roles/ansible/` carries its own `ansible_`-prefixed role variables (`ansible_mode`, `ansible_checkout_dir`, `ansible_otel_*`, `ansible_environment`, …) which a blind `sed` would have destroyed. Connection variables (`ansible_user`, `ansible_host`) and magic variables (`ansible_check_mode`, `ansible_version`) are likewise untouched, including the `ansible_env.USER` fallback in `run.fact.j2:68`.

## Test plan

- [x] `make lint-yaml` passes
- [x] `prettier` and `gitleaks` pre-commit hooks pass
- [x] Guard assertion: `ansible_(mode|repo|branch|checkout_dir|install_method|environment)` in `roles/ansible/` still counts 51 before and after, proving no role variable was migrated by mistake
- [x] Reference sweep over every `ansible_*` identifier in the repo: outside `roles/tuning`, the only remaining `ansible_`-prefixed names are role variables, connection variables, magic variables, and the documented `ansible_env.USER` fallback
- [x] CI green: `ansible-lint`, sanity tests (2.18/2.19/2.20), unit tests, all molecule scenarios, and all secret scans