### PR TITLE
refactor(makefile): skip lint and test targets when tooling is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,17 @@ tuning_optional_network_sysctl_params`. The previous single task
 
 ### Changed
 
+- **Makefile**: `lint-ansible`, `lint-python`, `test-unit`, `test-molecule` and
+  `test-molecule-%` now print `SKIP: <tool> not installed` and exit 0 when the
+  required tool is missing, instead of failing with exit 127. The molecule
+  targets additionally skip when the docker daemon does not answer (the `docker`
+  binary can be present without a running daemon). This only affects local
+  runs on hosts that lack the tooling: CI does not invoke `make`, it calls
+  `ansible-lint`, `ansible-test units` and `molecule test` directly through the
+  `arillso/.github` reusable workflows, so those gates are unchanged and remain
+  the authoritative verification. `lint-yaml`, `format`, `build`, `clean` and
+  `install-dev` are untouched, so `make lint` now reaches `lint-yaml` instead of
+  aborting at the first missing binary.
 - **Molecule (KVM converge)**: the `zram` and `tuning` scenarios now run a real
   converge + idempotence + verify under the `molecule-qemu` (KVM) driver on an
   Ubuntu 22.04 cloud-image VM, instead of the previous docker-driver,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,8 +129,12 @@ tuning_optional_network_sysctl_params`. The previous single task
 - **Makefile**: `lint-ansible`, `lint-python`, `test-unit`, `test-molecule` and
   `test-molecule-%` now print `SKIP: <tool> not installed` and exit 0 when the
   required tool is missing, instead of failing with exit 127. The molecule
-  targets additionally skip when the docker daemon does not answer (the `docker`
-  binary can be present without a running daemon). This only affects local
+  targets additionally skip a scenario when it declares the docker driver and
+  the daemon does not answer (the `docker` binary can be present without a
+  running daemon); the `zram` and `tuning` scenarios run under the
+  `molecule-qemu` (KVM) driver and are therefore never gated on docker, and in
+  `test-molecule` a skipped scenario no longer short-circuits the remaining
+  ones. This only affects local
   runs on hosts that lack the tooling: CI does not invoke `make`, it calls
   `ansible-lint`, `ansible-test units` and `molecule test` directly through the
   `arillso/.github` reusable workflows, so those gates are unchanged and remain

--- a/Makefile
+++ b/Makefile
@@ -8,22 +8,30 @@ help: ## Show this help message
 
 lint: lint-ansible lint-yaml lint-python ## Run all linters
 
-lint-ansible: ## Run ansible-lint
-	@echo "Running ansible-lint..."
-	@ansible-lint --force-color
+lint-ansible: ## Run ansible-lint (skipped when ansible-lint is missing; CI is the gate)
+	@if ! command -v ansible-lint >/dev/null 2>&1; then \
+		echo "SKIP: ansible-lint not installed"; \
+	else \
+		echo "Running ansible-lint..."; \
+		ansible-lint --force-color; \
+	fi
 
 lint-yaml: ## Run yamllint
 	@echo "Running yamllint..."
 	@yamllint .
 
-lint-python: ## Run Python linters (ruff, black)
-	@if [ -n "$$(find plugins/ -name '*.py' 2>/dev/null)" ]; then \
+lint-python: ## Run Python linters (skipped when ruff/black are missing; CI is the gate)
+	@if [ -z "$$(find plugins/ -name '*.py' 2>/dev/null)" ]; then \
+		echo "No Python plugins found, skipping..."; \
+	elif ! command -v ruff >/dev/null 2>&1; then \
+		echo "SKIP: ruff not installed"; \
+	elif ! command -v black >/dev/null 2>&1; then \
+		echo "SKIP: black not installed"; \
+	else \
 		echo "Running ruff..."; \
 		ruff check plugins/; \
 		echo "Running black..."; \
 		black --check plugins/; \
-	else \
-		echo "No Python plugins found, skipping..."; \
 	fi
 
 format: ## Auto-format Python code
@@ -38,20 +46,36 @@ format: ## Auto-format Python code
 
 test: test-unit ## Run unit tests (alias for test-unit)
 
-test-unit: ## Run pytest unit suite
-	@echo "Running pytest..."
-	@pytest tests/unit/
+test-unit: ## Run pytest unit suite (skipped when pytest is missing; CI is the gate)
+	@if ! command -v pytest >/dev/null 2>&1; then \
+		echo "SKIP: pytest not installed"; \
+	else \
+		echo "Running pytest..."; \
+		pytest tests/unit/; \
+	fi
 
-test-molecule: ## Run every molecule scenario (slow, needs docker)
-	@echo "Running every molecule scenario..."
-	@for s in $$(ls extensions/molecule | grep -v '^\.'); do \
-		echo "==> molecule test -s $$s"; \
-		(cd extensions && molecule test -s $$s) || exit $$?; \
-	done
+test-molecule: ## Run every molecule scenario (slow, needs docker; skipped when unavailable)
+	@if ! command -v molecule >/dev/null 2>&1; then \
+		echo "SKIP: molecule not installed"; \
+	elif ! docker info >/dev/null 2>&1; then \
+		echo "SKIP: docker daemon not available"; \
+	else \
+		echo "Running every molecule scenario..."; \
+		for s in $$(ls extensions/molecule | grep -v '^\.'); do \
+			echo "==> molecule test -s $$s"; \
+			(cd extensions && molecule test -s $$s) || exit $$?; \
+		done; \
+	fi
 
 test-molecule-%: ## Run a single molecule scenario (e.g. make test-molecule-access)
-	@echo "Running molecule scenario: $*"
-	@cd extensions && molecule test -s $*
+	@if ! command -v molecule >/dev/null 2>&1; then \
+		echo "SKIP: molecule not installed"; \
+	elif ! docker info >/dev/null 2>&1; then \
+		echo "SKIP: docker daemon not available"; \
+	else \
+		echo "Running molecule scenario: $*"; \
+		cd extensions && molecule test -s $*; \
+	fi
 
 build: ## Build collection
 	@echo "Building collection..."

--- a/Makefile
+++ b/Makefile
@@ -54,14 +54,22 @@ test-unit: ## Run pytest unit suite (skipped when pytest is missing; CI is the g
 		pytest tests/unit/; \
 	fi
 
-test-molecule: ## Run every molecule scenario (slow, needs docker; skipped when unavailable)
+# Scenarios declaring the docker driver need a reachable daemon; the qemu (KVM)
+# scenarios do not, so the daemon is checked per scenario, not globally.
+define molecule_needs_docker
+grep -qE '^[[:space:]]*name:[[:space:]]*docker[[:space:]]*$$' extensions/molecule/$(1)/molecule.yml
+endef
+
+test-molecule: ## Run every molecule scenario (slow; scenarios without their driver are skipped)
 	@if ! command -v molecule >/dev/null 2>&1; then \
 		echo "SKIP: molecule not installed"; \
-	elif ! docker info >/dev/null 2>&1; then \
-		echo "SKIP: docker daemon not available"; \
 	else \
 		echo "Running every molecule scenario..."; \
 		for s in $$(ls extensions/molecule | grep -v '^\.'); do \
+			if $(call molecule_needs_docker,$$s) && ! docker info >/dev/null 2>&1; then \
+				echo "SKIP $$s: docker daemon not available"; \
+				continue; \
+			fi; \
 			echo "==> molecule test -s $$s"; \
 			(cd extensions && molecule test -s $$s) || exit $$?; \
 		done; \
@@ -70,7 +78,7 @@ test-molecule: ## Run every molecule scenario (slow, needs docker; skipped when 
 test-molecule-%: ## Run a single molecule scenario (e.g. make test-molecule-access)
 	@if ! command -v molecule >/dev/null 2>&1; then \
 		echo "SKIP: molecule not installed"; \
-	elif ! docker info >/dev/null 2>&1; then \
+	elif $(call molecule_needs_docker,$*) && ! docker info >/dev/null 2>&1; then \
 		echo "SKIP: docker daemon not available"; \
 	else \
 		echo "Running molecule scenario: $*"; \


### PR DESCRIPTION
## Summary

- `lint-ansible`, `lint-python`, `test-unit`, `test-molecule` and `test-molecule-%` now print `SKIP: <tool> not installed` and exit 0 when the tool is absent, instead of failing with exit 127.
- The docker daemon is checked per molecule scenario, not globally: only scenarios declaring the docker driver require a reachable daemon, so the `zram` and `tuning` scenarios (`molecule-qemu`/KVM driver) still run, and in `test-molecule` a skipped scenario no longer short-circuits the remaining ones.
- CI is unaffected and remains the authoritative gate: no workflow invokes `make` (`rg -n 'make ' .github/` returns nothing); `pull-request.yml` delegates to the reusable `ci-ansible-collection.yml` and `ci-ansible-molecule.yml`, which call `ansible-lint`, `ansible-test units` and `molecule test` directly.
- `lint-yaml`, `format`, `build`, `clean` and `install-dev` are untouched, so `make lint` now reaches `lint-yaml` instead of aborting at the first missing binary.

## Test plan

- [x] `make lint` exits 0: SKIP for ansible-lint and ruff, yamllint runs for real
- [x] `make test` exits 0 with `SKIP: pytest not installed`
- [x] With fake binaries on `PATH`, each target enters its real branch and passes arguments unchanged (`--force-color`, `check plugins/`, `--check plugins/`, `tests/unit/`)
- [x] With a fake `molecule` on `PATH` and no docker daemon: `make test-molecule-access` skips, while `make test-molecule-zram` and `make test-molecule-tuning` run (qemu driver, not gated on docker)
- [x] `make test-molecule` skips the 13 docker scenarios individually and still reaches `tuning` and `zram`
- [x] Counterproof that something still fails: a deliberately broken YAML file makes `make lint-yaml` exit non-zero; `make build` still builds the collection with no SKIP
- [ ] CI green
