### PR TITLE
test(integration): add ansible-test targets for the custom modules

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -27,6 +27,7 @@ jobs:
             # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             enable_unit_tests: true
+            enable_integration_tests: true
 
     security-secrets:
         uses: arillso/.github/.github/workflows/security-secrets.yml@2026-08-07

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,6 +29,7 @@ jobs:
             # renovate: datasource=github-releases depName=python/cpython extractVersion=^v(?<version>3\.\d+)
             python_version: "3.12"
             enable_unit_tests: true
+            enable_integration_tests: true
 
     molecule:
         # Docker-driver scenarios (syntax/lint or real container converge).

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint lint-ansible lint-yaml lint-python format test test-unit test-molecule test-molecule-% build clean install-dev
+.PHONY: help lint lint-ansible lint-yaml lint-python format test test-unit test-integration test-molecule test-molecule-% build clean install-dev
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -52,6 +52,24 @@ test-unit: ## Run pytest unit suite (skipped when pytest is missing; CI is the g
 	else \
 		echo "Running pytest..."; \
 		pytest tests/unit/; \
+	fi
+
+test-integration: ## Run ansible-test integration targets (skipped when ansible-test/docker are missing; CI is the gate)
+	@if ! command -v ansible-test >/dev/null 2>&1; then \
+		echo "SKIP: ansible-test not installed"; \
+	elif ! docker info >/dev/null 2>&1; then \
+		echo "SKIP: docker daemon not available"; \
+	elif ! pwd -P | grep -q '/ansible_collections/[^/]*/[^/]*$$'; then \
+		echo "SKIP: ansible-test requires the collection to live in"; \
+		echo "      .../ansible_collections/arillso/system/ — CI does this via"; \
+		echo "      actions/checkout with path:. A symlink does not work because"; \
+		echo "      ansible-test resolves the real path; copy the tree instead:"; \
+		echo "        mkdir -p /tmp/ac/ansible_collections/arillso/system"; \
+		echo "        git archive HEAD | tar -x -C /tmp/ac/ansible_collections/arillso/system"; \
+		echo "        cd /tmp/ac/ansible_collections/arillso/system && make test-integration"; \
+	else \
+		echo "Running ansible-test integration..."; \
+		ansible-test integration --docker --color; \
 	fi
 
 # Scenarios declaring the docker driver need a reachable daemon; the qemu (KVM)

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,13 +1,16 @@
 # Tests — arillso.system
 
-This collection ships two complementary test suites:
+This collection ships three complementary test suites:
 
-| Layer                  | Path                               | What it verifies                                                    | When it runs                              |
-| ---------------------- | ---------------------------------- | ------------------------------------------------------------------- | ----------------------------------------- |
-| Unit tests             | `tests/unit/`                      | Plugin code in `plugins/{filter,lookup,modules}` (pure Python).     | Every push (`enable_unit_tests` in CI).   |
-| Molecule scenarios     | `extensions/molecule/<role>/`      | Role behaviour against real containers, one scenario per role.      | Manual locally, opt-in matrix in CI.      |
+| Layer               | Path                          | What it verifies                                                | When it runs                             |
+| ------------------- | ----------------------------- | --------------------------------------------------------------- | ---------------------------------------- |
+| Unit tests          | `tests/unit/`                 | Plugin code in `plugins/{filter,lookup,modules}` (pure Python). | Every push (`enable_unit_tests` in CI).  |
+| Integration targets | `tests/integration/targets/`  | The custom modules end-to-end against a live host.              | Every push (`enable_integration_tests`). |
+| Molecule scenarios  | `extensions/molecule/<role>/` | Role behaviour against real containers, one scenario per role.  | Manual locally, opt-in matrix in CI.     |
 
-The unit suite is the fast gate (sub-second). Molecule is the slow gate
+The unit suite is the fast gate (sub-second). Integration targets sit in
+between: they run the modules for real via `ansible-test`, but only cover
+`plugins/modules/`, not the roles. Molecule is the slow gate
 (minutes per scenario) and lives under `extensions/` so it ships inside
 the published collection tarball and runs from a Galaxy-installed
 collection without re-cloning the repo.
@@ -35,6 +38,54 @@ The suite covers:
 - `plugins/modules/reboot_info.py` — marker-file detection logic
   (without instantiating `AnsibleModule`, which couples to the
   ansible-core version).
+
+## Integration targets
+
+One target per custom module under `plugins/modules/`:
+
+```text
+tests/integration/targets/
+├── apt_update_info/
+│   ├── aliases                     # non_destructive
+│   └── tasks/main.yml
+└── reboot_info/
+    ├── aliases                     # non_destructive
+    └── tasks/main.yml
+```
+
+- `reboot_info` — creates and removes `/var/run/reboot-required` (the path
+  the module hardcodes) and asserts both return branches plus check mode.
+  The original marker state is restored in an `always` block, so a host
+  that really does have a pending reboot is left as it was found.
+- `apt_update_info` — asserts the _shape_ of the returned `packages` list:
+  it is a list, and every entry carries `package`, `current` and
+  `available`. The number of upgradable packages depends on how old the
+  container image is, so asserting a non-empty list would be flaky.
+
+Both targets guard themselves and end the host with a `debug` message when
+their preconditions are not met — `reboot_info` needs a writable `/var/run`,
+`apt_update_info` needs an APT-based host with `python-apt` and root. The
+guards are task-level on purpose: under `ansible-test integration --docker`
+only `skip/docker`, `skip/python*` and `skip/<arch>` aliases are honoured,
+so a `skip/<platform>` alias would silently not skip anything.
+
+```bash
+# ansible-test requires the collection to sit in an ansible_collections tree.
+# A symlink does not work — ansible-test resolves the real path.
+mkdir -p /tmp/ac/ansible_collections/arillso/system
+git archive HEAD | tar -x -C /tmp/ac/ansible_collections/arillso/system
+cd /tmp/ac/ansible_collections/arillso/system
+
+make test-integration
+# …which is equivalent to:
+ansible-test integration --docker --color
+
+# Run a single target
+ansible-test integration reboot_info --docker --color
+```
+
+CI does the same relocation with `actions/checkout` and a `path:` input, so
+the reusable workflow can call `ansible-test` directly.
 
 ## Molecule scenarios
 
@@ -137,10 +188,17 @@ The shortest path is to copy an adjacent role's directory and adjust:
 
 ### Running the full matrix in CI
 
-The repo's CI uses
-`arillso/.github/.github/workflows/ci-ansible-collection.yml`, which
-already supports a Molecule job — wire it up by adding a `scenarios:`
-input listing every scenario directory under
-`extensions/molecule/`. Until that input is set, Molecule runs are
-local-only and serve as a documented contract for what the roles
-should do.
+Every scenario is wired into CI via
+`arillso/.github/.github/workflows/ci-ansible-molecule.yml`, called three
+times from `.github/workflows/pull-request.yml`:
+
+- the `molecule` job runs the docker-driver scenarios (`access`,
+  `ansible`, `bitwarden_secrets`, `facts`, `firewall`, `logging`,
+  `network`, `packages`, `python`, `ready`, `shell`, `systemd`,
+  `thermal`),
+- `molecule-zram` and `molecule-tuning` run their kernel-bound scenario
+  under the `qemu` (KVM) driver, because a docker-driver job does not
+  provision QEMU/KVM.
+
+The matrix is pinned explicitly rather than auto-discovered so those two
+scenarios can be routed to the right driver.

--- a/tests/integration/targets/apt_update_info/aliases
+++ b/tests/integration/targets/apt_update_info/aliases
@@ -1,0 +1,1 @@
+non_destructive

--- a/tests/integration/targets/apt_update_info/tasks/main.yml
+++ b/tests/integration/targets/apt_update_info/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+# Integration coverage for the arillso.system.apt_update_info module.
+#
+# The module needs python-apt and root: it calls cache.update()
+# (plugins/modules/apt_update_info.py) and fails without privileges. The target
+# therefore guards itself on the package manager and on python-apt being
+# importable rather than relying on a skip/<platform> alias — under
+# `ansible-test integration --docker` only skip/docker, skip/python* and
+# skip/<arch> are evaluated, so a platform alias would not skip anything.
+#
+# The assertions cover the shape of the return value only. The set of
+# upgradable packages depends on how old the container image is, so asserting
+# a non-empty list would be flaky.
+
+- name: Check whether python-apt is importable on the test host
+  ansible.builtin.command: "{{ ansible_python_interpreter | default('/usr/bin/python3') }} -c 'import apt'"
+  register: apt_update_info_python_apt
+  changed_when: false
+  failed_when: false
+
+- name: End the host when apt_update_info cannot be exercised here
+  when: >-
+      ansible_facts['pkg_mgr'] != 'apt'
+      or apt_update_info_python_apt.rc != 0
+      or ansible_facts['effective_user_id'] != 0
+  block:
+      - name: Report why apt_update_info is not exercised
+        ansible.builtin.debug:
+            msg: >-
+                Skipping apt_update_info: pkg_mgr is {{ ansible_facts['pkg_mgr'] }},
+                python-apt import returned rc={{ apt_update_info_python_apt.rc }},
+                effective uid is {{ ansible_facts['effective_user_id'] }}. The module
+                requires an APT-based host with python-apt, running as root so that
+                cache.update() can refresh the APT cache.
+
+      - name: End the host
+        ansible.builtin.meta: end_host
+
+- name: Query apt_update_info
+  arillso.system.apt_update_info:
+  register: apt_update_info_result
+
+- name: Assert apt_update_info returns a package list
+  ansible.builtin.assert:
+      that:
+          - apt_update_info_result.packages is defined
+          - apt_update_info_result.packages is iterable
+          - apt_update_info_result.packages is not string
+          - not apt_update_info_result.changed
+      fail_msg: apt_update_info did not return a usable packages list.
+
+- name: Assert every reported package carries the documented keys
+  ansible.builtin.assert:
+      that:
+          - item.package is defined
+          - item.package is string
+          - item.current is defined
+          - item.current is string
+          - item.available is defined
+          - item.available is string
+      fail_msg: "apt_update_info returned an entry without the documented keys: {{ item }}"
+  loop: "{{ apt_update_info_result.packages }}"
+  loop_control:
+      label: "{{ item.package | default('<unnamed>') }}"
+
+- name: Report how many upgradable packages were seen
+  ansible.builtin.debug:
+      msg: >-
+          apt_update_info reported {{ apt_update_info_result.packages | length }}
+          upgradable package(s).

--- a/tests/integration/targets/reboot_info/aliases
+++ b/tests/integration/targets/reboot_info/aliases
@@ -1,0 +1,1 @@
+non_destructive

--- a/tests/integration/targets/reboot_info/tasks/main.yml
+++ b/tests/integration/targets/reboot_info/tasks/main.yml
@@ -1,0 +1,101 @@
+---
+# Integration coverage for the arillso.system.reboot_info module.
+#
+# The module hardcodes /var/run/reboot-required (plugins/modules/reboot_info.py),
+# so this target has to create and remove that exact path to exercise both
+# return branches. A pre-existing marker on the test host is left untouched:
+# it is restored in the always block instead of being deleted.
+
+- name: Record whether the host already reports a pending reboot
+  ansible.builtin.stat:
+      path: /var/run/reboot-required
+  register: reboot_info_marker_before
+
+- name: Check whether the marker path is writable
+  ansible.builtin.command: touch /var/run/.reboot_info_write_probe
+  register: reboot_info_write_probe
+  changed_when: false
+  failed_when: false
+
+- name: End the host when the marker path cannot be manipulated
+  when: reboot_info_write_probe.rc != 0
+  block:
+      - name: Report why reboot_info is not exercised
+        ansible.builtin.debug:
+            msg: >-
+                Skipping reboot_info: /var/run is not writable
+                (rc={{ reboot_info_write_probe.rc }}). This target needs to create and
+                remove /var/run/reboot-required, which requires a writable /var/run
+                and root privileges.
+
+      - name: End the host
+        ansible.builtin.meta: end_host
+
+- name: Remove the write probe
+  ansible.builtin.file:
+      path: /var/run/.reboot_info_write_probe
+      state: absent
+  changed_when: false
+
+- name: Exercise both branches of reboot_info
+  block:
+      - name: Remove the reboot marker so the negative branch is deterministic
+        ansible.builtin.file:
+            path: /var/run/reboot-required
+            state: absent
+
+      - name: Query reboot_info without a marker present
+        arillso.system.reboot_info:
+        register: reboot_info_without_marker
+
+      - name: Assert reboot_info reports no pending reboot
+        ansible.builtin.assert:
+            that:
+                - reboot_info_without_marker.reboot is defined
+                - reboot_info_without_marker.reboot is boolean
+                - not reboot_info_without_marker.reboot
+                - not reboot_info_without_marker.changed
+            fail_msg: >-
+                reboot_info reported {{ reboot_info_without_marker.reboot | default('<undefined>') }}
+                while /var/run/reboot-required was absent.
+
+      - name: Create the reboot marker
+        ansible.builtin.file:
+            path: /var/run/reboot-required
+            state: touch
+            mode: "0644"
+
+      - name: Query reboot_info with a marker present
+        arillso.system.reboot_info:
+        register: reboot_info_with_marker
+
+      - name: Assert reboot_info reports a pending reboot
+        ansible.builtin.assert:
+            that:
+                - reboot_info_with_marker.reboot is defined
+                - reboot_info_with_marker.reboot is boolean
+                - reboot_info_with_marker.reboot
+                - not reboot_info_with_marker.changed
+            fail_msg: >-
+                reboot_info reported {{ reboot_info_with_marker.reboot | default('<undefined>') }}
+                while /var/run/reboot-required was present.
+
+      - name: Query reboot_info in check mode with a marker present
+        arillso.system.reboot_info:
+        check_mode: true
+        register: reboot_info_check_mode
+
+      - name: Assert check mode returns the same result as a normal run
+        ansible.builtin.assert:
+            that:
+                - reboot_info_check_mode.reboot == reboot_info_with_marker.reboot
+                - not reboot_info_check_mode.changed
+            fail_msg: reboot_info returned a different result in check mode.
+
+  always:
+      - name: Restore the marker state the host started with
+        ansible.builtin.file:
+            path: /var/run/reboot-required
+            state: "{{ 'touch' if reboot_info_marker_before.stat.exists else 'absent' }}"
+            mode: "0644"
+        changed_when: false


### PR DESCRIPTION
## Summary

- Adds `tests/integration/targets/` with one target per custom module. `reboot_info` drives both return branches by creating and removing the marker file the module hardcodes, restoring the host's original state in an `always` block; `apt_update_info` asserts the shape of the returned `packages` list rather than its length, which depends on the container image's age.
- Both targets guard themselves on their preconditions and `end_host` with a reason. A `skip/<platform>` alias would not work here: under `ansible-test integration --docker` only `skip/docker`, `skip/python*` and `skip/<arch>` are evaluated, so the alias would silently skip nothing.
- Turns on `enable_integration_tests` in both callers, adds a `make test-integration` target that explains the `ansible_collections/` layout requirement, and documents the new layer in `tests/README.md`.

## Test plan

- [x] `ansible-test integration --list-targets` discovers both targets
- [x] Both targets run green (locally via `--local`; both hit their guards on an unprivileged host, which is the documented behaviour)
- [x] Assertions proven non-vacuous: against a writable marker path all asserts execute and pass, and a deliberately broken module makes the target fail with the intended message
- [x] `yamllint` and `ansible-lint` (production profile) clean
- [x] `ansible-test sanity` subset that runs without network: `no-illegal-filenames`, `no-smart-quotes`, `symlinks`, `shebang`
- [ ] CI runs the new targets under `--docker` as root, where both guards pass and the assertions execute