### PR TITLE
docs(skills): add build procedure for roles and plugins

### DIFF
--- a/.claude/skills/adding-role-or-plugin/SKILL.md
+++ b/.claude/skills/adding-role-or-plugin/SKILL.md
@@ -36,7 +36,8 @@ depends on the plugin type:
 Filters are the trap: `plugins/filter/nftables.py` and `plugins/filter/toml.py`
 contain no documentation blocks at all. Each filter gets its own sidecar YAML,
 one per filter — not one per Python file. `plugins/filter/to_toml.yml` is the
-reference; it also shows `options`, `requirements` and `seealso`.
+reference for `requirements` and `seealso`; see `plugins/filter/from_toml.yml`
+for an `options` block.
 
 ## Before Opening a PR
 

--- a/.claude/skills/adding-role-or-plugin/SKILL.md
+++ b/.claude/skills/adding-role-or-plugin/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: adding-role-or-plugin
+description: Use when adding a new role or a new plugin (module, lookup, or filter) to the arillso.system collection, or when checking that an existing one carries the required files. Covers the mandatory role scaffold including meta/argument_specs.yml, and where plugin documentation lives per plugin type — inline for modules and lookups, sidecar YAML for filters. Not for editing task logic in an existing role.
+---
+
+# Adding a Role or Plugin
+
+## Adding a Role
+
+Every one of the 15 roles carries these five files. A new role without them is
+incomplete:
+
+- `README.md` — description, variables, example play
+- `meta/main.yml`
+- `meta/argument_specs.yml` — validates role arguments; mandatory, not optional
+- `tasks/main.yml`
+- `defaults/main.yml` — every variable documented with a comment
+
+Add when the role needs them (not present in every role today):
+`handlers/main.yml`, `vars/main.yml`, `templates/`.
+
+Copy the argument spec shape from an existing role, e.g.
+`roles/systemd/meta/argument_specs.yml`.
+
+## Adding a Plugin
+
+All plugins document `DOCUMENTATION`, `EXAMPLES` and `RETURN`. The location
+depends on the plugin type:
+
+| Type   | Code                        | Documentation                         |
+| ------ | --------------------------- | ------------------------------------- |
+| module | `plugins/modules/<name>.py` | inline, same file                     |
+| lookup | `plugins/lookup/<name>.py`  | inline, same file                     |
+| filter | `plugins/filter/<file>.py`  | `plugins/filter/<filter>.yml` sidecar |
+
+Filters are the trap: `plugins/filter/nftables.py` and `plugins/filter/toml.py`
+contain no documentation blocks at all. Each filter gets its own sidecar YAML,
+one per filter — not one per Python file. `plugins/filter/to_toml.yml` is the
+reference; it also shows `options`, `requirements` and `seealso`.
+
+## Before Opening a PR
+
+Run `make lint` and `make test`.
+
+Both targets skip silently when the tool is missing locally
+(`SKIP: ansible-lint not installed`, `SKIP: pytest not installed`), so a green
+local run proves nothing. The binding gate is the reusable CI in
+`.github/workflows/pull-request.yml`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,11 @@ Key roles:
 - Document role variables in defaults/main.yml with comments
 - Keep collection-level documentation in main README.md
 
+### Adding a Role or Plugin
+
+Required files and the per-type plugin documentation layout are documented in
+the `adding-role-or-plugin` skill (`.claude/skills/adding-role-or-plugin/`).
+
 ## Workflows
 
 ### CI/CD


### PR DESCRIPTION
## Summary

- Adds a `adding-role-or-plugin` skill under `.claude/skills/` that records the required files for a new role (including `meta/argument_specs.yml`) and where plugin documentation belongs per plugin type.
- Filters are the trap the skill exists for: `plugins/filter/*.py` carry no documentation blocks at all, the docs live in one sidecar YAML per filter. Without this written down, a new filter's docs land in the Python file and never surface.
- `AGENTS.md` gains a five-line pointer instead of the full procedure, so the auto-loaded context stays at its current size and the detail loads only when someone actually adds a role or plugin.

## Test plan

- [ ] `markdownlint-cli2 AGENTS.md '.claude/skills/**/*.md'` reports 0 issues
- [ ] Mandatory role files verified against the repo: `README.md`, `meta/main.yml`, `meta/argument_specs.yml`, `tasks/main.yml`, `defaults/main.yml` are present in 15/15 roles
- [ ] Optional files confirmed as not universal: `handlers/main.yml` 14/15, `vars/main.yml` 11/15, `templates/` 12/15
- [ ] Plugin doc layout confirmed: 4 module/lookup files carry inline `DOCUMENTATION`, both filter `.py` files carry none, 6 filter sidecar YAMLs exist
- [ ] CI green
